### PR TITLE
feat(das): add das api

### DIFF
--- a/.github/workflows/test-js-client.yml
+++ b/.github/workflows/test-js-client.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Test
         working-directory: ./clients/js
-        run: pnpm test
+        run: pnpm test -- --match='!das:*'
 
   lint:
     name: Lint

--- a/clients/js/.env.example
+++ b/clients/js/.env.example
@@ -1,0 +1,1 @@
+DAS_API_ENDPOINT="https://example.das-rpc.com"

--- a/clients/js/.gitignore
+++ b/clients/js/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 docs
+.env

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -26,8 +26,9 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "peerDependencies": {
-    "@metaplex-foundation/umi": "^0.8.2",
+    "@metaplex-foundation/digital-asset-standard-api": "^1.0.3",
     "@metaplex-foundation/mpl-toolbox": "^0.8.0",
+    "@metaplex-foundation/umi": "^0.8.2",
     "@noble/hashes": "^1.3.1"
   },
   "devDependencies": {
@@ -39,6 +40,7 @@
     "@typescript-eslint/parser": "^5.46.1",
     "ava": "^5.1.0",
     "bs58": "5.0.0",
+    "dotenv": "^16.4.5",
     "eslint": "^8.0.1",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.5.0",
@@ -59,7 +61,10 @@
         "src/": "dist/src/",
         "test/": "dist/test/"
       }
-    }
+    },
+    "require": [
+      "dotenv/config"
+    ]
   },
   "packageManager": "pnpm@8.2.0"
 }

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@metaplex-foundation/digital-asset-standard-api':
+    specifier: ^1.0.3
+    version: 1.0.3(@metaplex-foundation/umi@0.8.2)
   '@metaplex-foundation/mpl-toolbox':
     specifier: ^0.8.0
     version: 0.8.0(@metaplex-foundation/umi@0.8.2)
@@ -37,6 +40,9 @@ devDependencies:
   bs58:
     specifier: 5.0.0
     version: 5.0.0
+  dotenv:
+    specifier: ^16.4.5
+    version: 16.4.5
   eslint:
     specifier: ^8.0.1
     version: 8.0.1
@@ -1861,6 +1867,15 @@ packages:
       - supports-color
     dev: true
 
+  /@metaplex-foundation/digital-asset-standard-api@1.0.3(@metaplex-foundation/umi@0.8.2):
+    resolution: {integrity: sha512-uWrKF3lGfDt5KB1xV5BfPFQnbq4GvcNsN2/YYdgFW6+iNplhzXibbYjrZDFRv+WcE49U8JKbxK/yDW+Jc6K9Cw==}
+    peerDependencies:
+      '@metaplex-foundation/umi': '>= 0.8.2 < 1'
+    dependencies:
+      '@metaplex-foundation/umi': 0.8.2
+      package.json: 2.0.1
+    dev: false
+
   /@metaplex-foundation/mpl-toolbox@0.8.0(@metaplex-foundation/umi@0.8.2):
     resolution: {integrity: sha512-SK1VUPU4hCaL3sozgtoVjjbZxqx2gWiRt0YTFbwEt5LAHWOlCb7J7rcrrA5XwymX4iV2bIWygYs0yz7hYyx2rg==}
     peerDependencies:
@@ -2428,7 +2443,6 @@ packages:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
       '@types/node': 20.11.28
-    dev: true
 
   /@types/mdast@3.0.15:
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
@@ -2460,7 +2474,6 @@ packages:
     resolution: {integrity: sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
@@ -2478,7 +2491,6 @@ packages:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
       '@types/node': 20.11.28
-    dev: true
 
   /@types/scheduler@0.16.8:
     resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
@@ -2866,6 +2878,12 @@ packages:
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
+
+  /abs@1.3.14:
+    resolution: {integrity: sha512-PrS26IzwKLWwuURpiKl8wRmJ2KdR/azaVrLEBWG/TALwT20Y7qjtYp1qcMLHA4206hBHY5phv3w4pjf9NPv4Vw==}
+    dependencies:
+      ul: 5.2.15
+    dev: false
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3475,6 +3493,11 @@ packages:
     resolution: {integrity: sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==}
     dev: true
 
+  /capture-stack-trace@1.0.2:
+    resolution: {integrity: sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /cbor@8.1.0:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
     engines: {node: '>=12.19'}
@@ -3746,7 +3769,13 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: true
+
+  /create-error-class@3.0.2:
+    resolution: {integrity: sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      capture-stack-trace: 1.0.2
+    dev: false
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -3879,6 +3908,11 @@ packages:
       mimic-response: 3.1.0
     dev: true
 
+  /deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -3902,6 +3936,12 @@ packages:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
     engines: {node: '>=10'}
     dev: true
+
+  /deffy@2.2.4:
+    resolution: {integrity: sha512-pLc9lsbsWjr6RxmJ2OLyvm+9l4j1yK69h+TML/gUit/t3vTijpkNGh8LioaJYTGO7F25m6HZndADcUOo2PsiUg==}
+    dependencies:
+      typpy: 2.3.13
+    dev: false
 
   /define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -4020,6 +4060,12 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+    dependencies:
+      readable-stream: 2.3.8
+    dev: false
+
   /duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
     dependencies:
@@ -4092,6 +4138,18 @@ packages:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
     dev: true
+
+  /err@1.1.1:
+    resolution: {integrity: sha512-N97Ybd2jJHVQ+Ft3Q5+C2gM3kgygkdeQmEqbN2z15UTVyyEsIwLA1VK39O1DHEJhXbwIFcJLqm6iARNhFANcQA==}
+    dependencies:
+      typpy: 2.3.13
+    dev: false
+
+  /error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    dependencies:
+      is-arrayish: 0.2.1
+    dev: false
 
   /es-abstract@1.22.5:
     resolution: {integrity: sha512-oW69R+4q2wG+Hc3KZePPZxOiisRIqfKBVo/HLx94QcJeWGU/8sZhCvc829rd1kS366vlJbzBfXf9yWwf0+Ko7w==}
@@ -4876,6 +4934,13 @@ packages:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: true
 
+  /exec-limiter@3.2.13:
+    resolution: {integrity: sha512-86Ri699bwiHZVBzTzNj8gspqAhCPchg70zPVWIh3qzUOA1pUMcb272Em3LPk8AE0mS95B9yMJhtqF8vFJAn0dA==}
+    dependencies:
+      limit-it: 3.2.10
+      typpy: 2.3.13
+    dev: false
+
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -5170,7 +5235,12 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
+
+  /function.name@1.0.13:
+    resolution: {integrity: sha512-mVrqdoy5npWZyoXl4DxCeuVF6delDcQjVS9aPdvLYlBxtMTZDR2B5GVEQEoM1jJyspCqg3C0v4ABkLE7tp9xFA==}
+    dependencies:
+      noop6: 1.0.9
+    dev: false
 
   /function.prototype.name@1.1.6:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
@@ -5276,6 +5346,39 @@ packages:
     resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
     dev: true
 
+  /git-package-json@1.4.10:
+    resolution: {integrity: sha512-DRAcvbzd2SxGK7w8OgYfvKqhFliT5keX0lmSmVdgScgf1kkl5tbbo7Pam6uYoCa1liOiipKxQZG8quCtGWl/fA==}
+    dependencies:
+      deffy: 2.2.4
+      err: 1.1.1
+      gry: 5.0.8
+      normalize-package-data: 2.5.0
+      oargv: 3.4.10
+      one-by-one: 3.2.8
+      r-json: 1.3.0
+      r-package-json: 1.0.9
+      tmp: 0.0.28
+    dev: false
+
+  /git-source@1.1.10:
+    resolution: {integrity: sha512-XZZ7ZgnLL35oLgM/xjnLYgtlKlxJG0FohC1kWDvGkU7s1VKGXK0pFF/g1itQEwQ3D+uTQzBnzPi8XbqOv7Wc1Q==}
+    dependencies:
+      git-url-parse: 5.0.1
+    dev: false
+
+  /git-up@1.2.1:
+    resolution: {integrity: sha512-SRVN3rOLACva8imc7BFrB6ts5iISWKH1/h/1Z+JZYoUI7UVQM7gQqk4M2yxUENbq2jUUT09NEND5xwP1i7Ktlw==}
+    dependencies:
+      is-ssh: 1.4.0
+      parse-url: 1.3.11
+    dev: false
+
+  /git-url-parse@5.0.1:
+    resolution: {integrity: sha512-4uSiOgrryNEMBX+gTWogenYRUh2j1D+95STTSEF2RCTgLkfJikl8c7BGr0Bn274hwuxTsbS2/FQ5pVS9FoXegQ==}
+    dependencies:
+      git-up: 1.2.1
+    dev: false
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -5380,9 +5483,41 @@ packages:
       responselike: 2.0.1
     dev: true
 
+  /got@5.7.1:
+    resolution: {integrity: sha512-1qd54GLxvVgzuidFmw9ze9umxS3rzhdBH6Wt6BTYrTQUXTN01vGGYXwzLzYLowNx8HBH3/c7kRyvx90fh13i7Q==}
+    engines: {node: '>=0.10.0 <7'}
+    dependencies:
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.3
+      create-error-class: 3.0.2
+      duplexer2: 0.1.4
+      is-redirect: 1.0.0
+      is-retry-allowed: 1.2.0
+      is-stream: 1.1.0
+      lowercase-keys: 1.0.1
+      node-status-codes: 1.0.0
+      object-assign: 4.1.1
+      parse-json: 2.2.0
+      pinkie-promise: 2.0.1
+      read-all-stream: 3.1.0
+      readable-stream: 2.3.8
+      timed-out: 3.1.3
+      unzip-response: 1.0.2
+      url-parse-lax: 1.0.0
+    dev: false
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
+
+  /gry@5.0.8:
+    resolution: {integrity: sha512-meq9ZjYVpLzZh3ojhTg7IMad9grGsx6rUUKHLqPnhLXzJkRQvEL2U3tQpS5/WentYTtHtxkT3Ew/mb10D6F6/g==}
+    dependencies:
+      abs: 1.3.14
+      exec-limiter: 3.2.13
+      one-by-one: 3.2.8
+      ul: 5.2.15
+    dev: false
 
   /gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
@@ -5447,7 +5582,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /hast-util-to-estree@2.3.3:
     resolution: {integrity: sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==}
@@ -5474,6 +5608,10 @@ packages:
   /hast-util-whitespace@2.0.1:
     resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
     dev: true
+
+  /hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+    dev: false
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -5606,7 +5744,10 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
+
+  /ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: false
 
   /inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
@@ -5683,6 +5824,10 @@ packages:
       get-intrinsic: 1.2.4
     dev: true
 
+  /is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: false
+
   /is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
     dependencies:
@@ -5718,7 +5863,6 @@ packages:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
       hasown: 2.0.2
-    dev: true
 
   /is-data-view@1.0.1:
     resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
@@ -5833,6 +5977,11 @@ packages:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
     dev: true
 
+  /is-redirect@1.0.0:
+    resolution: {integrity: sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
     dependencies:
@@ -5847,12 +5996,28 @@ packages:
       has-tostringtag: 1.0.2
     dev: true
 
+  /is-retry-allowed@1.2.0:
+    resolution: {integrity: sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /is-shared-array-buffer@1.0.3:
     resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.7
     dev: true
+
+  /is-ssh@1.4.0:
+    resolution: {integrity: sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==}
+    dependencies:
+      protocols: 2.0.1
+    dev: false
+
+  /is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -5902,7 +6067,6 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: true
 
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -5919,6 +6083,10 @@ packages:
     dependencies:
       ws: 7.5.9
     dev: true
+
+  /iterate-object@1.3.4:
+    resolution: {integrity: sha512-4dG1D1x/7g8PwHS9aK6QV5V94+ZvyP4+d19qDv43EzImmrndysIl4prmJ1hWWIGCqrZHyaHBm6BSEWHOLnpoNw==}
+    dev: false
 
   /javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
@@ -6086,6 +6254,12 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /limit-it@3.2.10:
+    resolution: {integrity: sha512-T0NK99pHnkimldr1WUqvbGV1oWDku/xC9J/OqzJFsV1jeOS6Bwl8W7vkeQIBqwiON9dTALws+rX/XPMQqWerDQ==}
+    dependencies:
+      typpy: 2.3.13
+    dev: false
+
   /load-json-file@7.0.1:
     resolution: {integrity: sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -6146,6 +6320,11 @@ packages:
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
     dev: true
+
+  /lowercase-keys@1.0.1:
+    resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -6718,7 +6897,6 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /minipass-collect@1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
@@ -6827,6 +7005,7 @@ packages:
 
   /node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -6863,10 +7042,19 @@ packages:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
 
+  /node-status-codes@1.0.0:
+    resolution: {integrity: sha512-1cBMgRxdMWE8KeWCqk2RIOrvUb0XCwYfEsY5/y2NlXyq4Y/RumnOZvTj4Nbr77+Vb2C+kyBoRTdkNOS8L3d/aQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /nofilter@3.1.0:
     resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
     engines: {node: '>=12.19'}
     dev: true
+
+  /noop6@1.0.9:
+    resolution: {integrity: sha512-DB3Hwyd89dPr5HqEPg3YHjzvwh/mCqizC1zZ8vyofqc+TQRyPDnT4wgXXbLGF4z9YAzwwTLi8pNLhGqcbSjgkA==}
+    dev: false
 
   /nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -6875,6 +7063,15 @@ packages:
     dependencies:
       abbrev: 1.1.1
     dev: true
+
+  /normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.8
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+    dev: false
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -6902,10 +7099,22 @@ packages:
       set-blocking: 2.0.0
     dev: true
 
+  /oargv@3.4.10:
+    resolution: {integrity: sha512-SXaMANv9sr7S/dP0vj0+Ybipa47UE1ntTWQ2rpPRhC6Bsvfl+Jg03Xif7jfL0sWKOYWK8oPjcZ5eJ82t8AP/8g==}
+    dependencies:
+      iterate-object: 1.3.4
+      ul: 5.2.15
+    dev: false
+
+  /obj-def@1.0.9:
+    resolution: {integrity: sha512-bQ4ya3VYD6FAA1+s6mEhaURRHSmw4+sKaXE6UyXZ1XDYc5D+c7look25dFdydmLd18epUegh398gdDkMUZI9xg==}
+    dependencies:
+      deffy: 2.2.4
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
@@ -6957,6 +7166,13 @@ packages:
       wrappy: 1.0.2
     dev: true
 
+  /one-by-one@3.2.8:
+    resolution: {integrity: sha512-HR/pSzZdm46Xqj58K+Bu64kMbSTw8/u77AwWvV+rprO/OsuR++pPlkUJn+SmwqBGRgHKwSKQ974V3uls7crIeQ==}
+    dependencies:
+      obj-def: 1.0.9
+      sliced: 1.0.1
+    dev: false
+
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -7006,7 +7222,6 @@ packages:
   /os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /outdent@0.8.0:
     resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
@@ -7102,6 +7317,31 @@ packages:
       netmask: 2.0.2
     dev: true
 
+  /package-json-path@1.0.9:
+    resolution: {integrity: sha512-uNu7f6Ef7tQHZRnkyVnCtzdSYVN9uBtge/sG7wzcUaawFWkPYUq67iXxRGrQSg/q0tzxIB8jSyIYUKjG2Jn//A==}
+    dependencies:
+      abs: 1.3.14
+    dev: false
+
+  /package-json@2.4.0:
+    resolution: {integrity: sha512-PRg65iXMTt/uK8Rfh5zvzkUbfAPitF17YaCY+IbHsYgksiLvtzWWTUildHth3mVaZ7871OJ7gtP4LBRBlmAdXg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      got: 5.7.1
+      registry-auth-token: 3.4.0
+      registry-url: 3.1.0
+      semver: 5.7.2
+    dev: false
+
+  /package.json@2.0.1:
+    resolution: {integrity: sha512-pSxZ6XR5yEawRN2ekxx9IKgPN5uNAYco7MCPxtBEWMKO3UKWa1X2CtQMzMgloeGj2g2o6cue3Sb5iPkByIJqlw==}
+    deprecated: Use pkg.json instead.
+    dependencies:
+      git-package-json: 1.4.10
+      git-source: 1.1.10
+      package-json: 2.4.0
+    dev: false
+
   /pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
     dev: true
@@ -7126,6 +7366,13 @@ packages:
       is-hexadecimal: 2.0.1
     dev: true
 
+  /parse-json@2.2.0:
+    resolution: {integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      error-ex: 1.3.2
+    dev: false
+
   /parse-ms@2.1.0:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
@@ -7135,6 +7382,13 @@ packages:
     resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
     engines: {node: '>=12'}
     dev: true
+
+  /parse-url@1.3.11:
+    resolution: {integrity: sha512-1wj9nkgH/5EboDxLwaTMGJh3oH3f+Gue+aGdh631oCqoSBpokzmMmOldvOeBPtB8GJBYJbaF93KPzlkU+Y1ksg==}
+    dependencies:
+      is-ssh: 1.4.0
+      protocols: 1.4.8
+    dev: false
 
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -7167,7 +7421,6 @@ packages:
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-    dev: true
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -7214,6 +7467,18 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: true
+
+  /pinkie-promise@2.0.1:
+    resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      pinkie: 2.0.4
+    dev: false
+
+  /pinkie@2.0.4:
+    resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /pkg-conf@4.0.0:
     resolution: {integrity: sha512-7dmgi4UY4qk+4mj5Cd8v/GExPo0K+SlY+hulOSdfZ/T6jVH6//y7NtzZo5WrfhDBxuQ0jCa7fLZmNaNh7EWL/w==}
@@ -7340,6 +7605,11 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /prepend-http@1.0.4:
+    resolution: {integrity: sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
@@ -7380,7 +7650,6 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-    dev: true
 
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -7399,6 +7668,14 @@ packages:
   /property-information@6.4.1:
     resolution: {integrity: sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==}
     dev: true
+
+  /protocols@1.4.8:
+    resolution: {integrity: sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==}
+    dev: false
+
+  /protocols@2.0.1:
+    resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
+    dev: false
 
   /proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -7471,6 +7748,19 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /r-json@1.3.0:
+    resolution: {integrity: sha512-xesd+RHCpymPCYd9DvDvUr1w1IieSChkqYF1EpuAYrvCfLXji9NP36DvyYZJZZB5soVDvZ0WUtBoZaU1g5Yt9A==}
+    dependencies:
+      w-json: 1.3.10
+    dev: false
+
+  /r-package-json@1.0.9:
+    resolution: {integrity: sha512-G4Vpf1KImWmmPFGdtWQTU0L9zk0SjqEC4qs/jE7AQ+Ylmr5kizMzGeC4wnHp5+ijPqNN+2ZPpvyjVNdN1CDVcg==}
+    dependencies:
+      package-json-path: 1.0.9
+      r-json: 1.3.0
+    dev: false
+
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -7485,6 +7775,24 @@ packages:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
     dev: true
+
+  /rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    dev: false
+
+  /read-all-stream@3.1.0:
+    resolution: {integrity: sha512-DI1drPHbmBcUDWrJ7ull/F2Qb8HkwBncVx8/RpKYFSIACYaVRQReISYPdZz/mt1y1+qMCOrfReTopERmaxtP6w==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      pinkie-promise: 2.0.1
+      readable-stream: 2.3.8
+    dev: false
 
   /readable-stream@1.1.14:
     resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
@@ -7505,7 +7813,6 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-    dev: true
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -7584,6 +7891,20 @@ packages:
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.1.0
     dev: true
+
+  /registry-auth-token@3.4.0:
+    resolution: {integrity: sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==}
+    dependencies:
+      rc: 1.2.8
+      safe-buffer: 5.2.1
+    dev: false
+
+  /registry-url@3.1.0:
+    resolution: {integrity: sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      rc: 1.2.8
+    dev: false
 
   /regjsparser@0.9.1:
     resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
@@ -7672,7 +7993,6 @@ packages:
       is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    dev: true
 
   /responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
@@ -7792,11 +8112,9 @@ packages:
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: true
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
   /safe-regex-test@1.0.3:
     resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
@@ -7810,6 +8128,11 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
+
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: false
 
   /semver@6.1.1:
     resolution: {integrity: sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==}
@@ -7960,6 +8283,10 @@ packages:
       is-fullwidth-code-point: 4.0.0
     dev: true
 
+  /sliced@1.0.1:
+    resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    dev: false
+
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -8023,6 +8350,28 @@ packages:
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
     dev: true
+
+  /spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.17
+    dev: false
+
+  /spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+    dev: false
+
+  /spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.17
+    dev: false
+
+  /spdx-license-ids@3.0.17:
+    resolution: {integrity: sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==}
+    dev: false
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -8111,7 +8460,6 @@ packages:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
       safe-buffer: 5.1.2
-    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -8149,6 +8497,11 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
+
+  /strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -8192,7 +8545,6 @@ packages:
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
@@ -8261,6 +8613,18 @@ packages:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
     dev: true
+
+  /timed-out@3.1.3:
+    resolution: {integrity: sha512-3RB4qgvPkxF/FGPnrzaWLhW1rxNK2sdH0mFjbhxkfTR6QXvcM3EtYm9L44UrhODZrZ+yhDXeMncLqi8QXn2MJg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /tmp@0.0.28:
+    resolution: {integrity: sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: false
 
   /tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -8499,9 +8863,22 @@ packages:
     hasBin: true
     dev: true
 
+  /typpy@2.3.13:
+    resolution: {integrity: sha512-vOxIcQz9sxHi+rT09SJ5aDgVgrPppQjwnnayTrMye1ODaU8gIZTDM19t9TxmEElbMihx2Nq/0/b/MtyKfayRqA==}
+    dependencies:
+      function.name: 1.0.13
+    dev: false
+
   /ufo@1.5.2:
     resolution: {integrity: sha512-eiutMaL0J2MKdhcOM1tUy13pIrYnyR87fEd8STJQFrrAwImwvlXkxlZEjaKah8r2viPohld08lt73QfLG1NxMg==}
     dev: true
+
+  /ul@5.2.15:
+    resolution: {integrity: sha512-svLEUy8xSCip5IWnsRa0UOg+2zP0Wsj4qlbjTmX6GJSmvKMHADBuHOm1dpNkWqWPIGuVSqzUkV3Cris5JrlTRQ==}
+    dependencies:
+      deffy: 2.2.4
+      typpy: 2.3.13
+    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
@@ -8514,7 +8891,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -8634,6 +9010,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /unzip-response@1.0.2:
+    resolution: {integrity: sha512-pwCcjjhEcpW45JZIySExBHYv5Y9EeL2OIGEfrSKp2dMUFGFv4CpvZkwJbVge8OvGH2BNNtJBx67DuKuJhf+N5Q==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -8651,6 +9032,13 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /url-parse-lax@1.0.0:
+    resolution: {integrity: sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      prepend-http: 1.0.4
+    dev: false
+
   /utf-8-validate@5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
     engines: {node: '>=6.14.2'}
@@ -8661,7 +9049,6 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
 
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -8691,6 +9078,13 @@ packages:
   /v8-compile-cache@2.4.0:
     resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
     dev: true
+
+  /validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+    dev: false
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -8821,6 +9215,10 @@ packages:
   /vscode-textmate@6.0.0:
     resolution: {integrity: sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==}
     dev: true
+
+  /w-json@1.3.10:
+    resolution: {integrity: sha512-XadVyw0xE+oZ5FGApXsdswv96rOhStzKqL53uSe5UaTadABGkWIg1+DTx8kiZ/VqTZTBneoL0l65RcPe4W3ecw==}
+    dev: false
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}

--- a/clients/js/src/das.ts
+++ b/clients/js/src/das.ts
@@ -1,0 +1,328 @@
+import {
+  AccountHeader,
+  BigIntInput,
+  lamports,
+  none,
+  PublicKey,
+  publicKey,
+  some,
+  Umi,
+} from '@metaplex-foundation/umi';
+import {
+  DasApiAsset,
+  DasApiAssetAuthority,
+  DasApiAssetGrouping,
+  DasApiAssetInterface,
+  SearchAssetsRpcInput,
+} from '@metaplex-foundation/digital-asset-standard-api';
+import {
+  AssetV1,
+  Attributes,
+  BurnDelegate,
+  CollectionV1,
+  FreezeDelegate,
+  Key,
+  MPL_CORE_PROGRAM_ID,
+  PermanentBurnDelegate,
+  PermanentFreezeDelegate,
+  PermanentTransferDelegate,
+  Royalties,
+  RuleSet,
+  ruleSet,
+  TransferDelegate,
+  UpdateDelegate,
+} from './generated';
+import { BaseUpdateAuthority, PluginsList } from './types';
+
+type Pagination = Pick<
+  SearchAssetsRpcInput,
+  'sortBy' | 'limit' | 'page' | 'before' | 'after'
+>;
+
+const MPL_CORE_ASSET = 'MplCoreAsset';
+const MPL_CORE_COLLECTION = 'MplCoreCollection';
+
+function convertSnakeCase(str: string, toCase: 'pascal' | 'camel' = 'camel') {
+  return str
+    .toLowerCase()
+    .split('_')
+    .map((word, index) =>
+      toCase === 'camel' && index === 0
+        ? word
+        : word.charAt(0).toUpperCase() + word.slice(1)
+    )
+    .join('');
+}
+
+function getUpdateAuthority(
+  groupingItem: DasApiAssetGrouping | undefined,
+  authority: DasApiAssetAuthority
+): Record<'updateAuthority', BaseUpdateAuthority> {
+  const result: { updateAuthority: BaseUpdateAuthority } = {
+    updateAuthority: { type: 'None' },
+  };
+
+  if (groupingItem && groupingItem.group_key === 'collection') {
+    result.updateAuthority = {
+      type: 'Collection',
+      address: publicKey(groupingItem.group_value),
+    };
+  } else {
+    result.updateAuthority = {
+      type: 'Address',
+      address: authority.address,
+    };
+  }
+
+  return result;
+}
+
+function getAccountHeader(
+  executable?: boolean,
+  lamps?: BigIntInput,
+  rentEpoch?: number
+): Record<'header', AccountHeader> {
+  return {
+    header: {
+      executable: executable ?? false,
+      owner: MPL_CORE_PROGRAM_ID,
+      lamports: lamports(lamps ?? -1),
+      ...(rentEpoch !== undefined ? { rentEpoch } : {}),
+    },
+  };
+}
+
+function getRuleSet(dasRuleSet: string | Record<string, any>): RuleSet {
+  const isRuleSetString = typeof dasRuleSet === 'string';
+  const ruleSetKind = isRuleSetString ? dasRuleSet : Object.keys(dasRuleSet)[0];
+  const ruleSetData: PublicKey[] = !isRuleSetString
+    ? dasRuleSet[ruleSetKind].map((bytes: Uint8Array) =>
+        publicKey(new Uint8Array(bytes))
+      )
+    : [];
+
+  if (ruleSetKind === 'program_allow_list') {
+    return ruleSet('ProgramAllowList', [ruleSetData]);
+  }
+
+  if (ruleSetKind === 'program_deny_list') {
+    return ruleSet('ProgramDenyList', [ruleSetData]);
+  }
+
+  return ruleSet('None');
+}
+
+function dasPluginDataToCorePluginData(
+  dasPluginData: Record<string, any>
+):
+  | Royalties
+  | FreezeDelegate
+  | BurnDelegate
+  | TransferDelegate
+  | UpdateDelegate
+  | PermanentFreezeDelegate
+  | Attributes
+  | PermanentTransferDelegate
+  | PermanentBurnDelegate {
+  return (({
+    basis_points,
+    creators,
+    rule_set,
+    attribute_list,
+    frozen,
+    additional_delegates,
+  }) => ({
+    ...(basis_points !== undefined ? { basisPoints: basis_points } : {}),
+    ...(creators !== undefined
+      ? {
+          creators: creators.map((creator: any) => ({
+            ...creator,
+            address: publicKey(creator.address),
+          })),
+        }
+      : {}),
+    ...(rule_set !== undefined ? { ruleSet: getRuleSet(rule_set) } : {}),
+    ...(attribute_list !== undefined ? { attributeList: attribute_list } : {}),
+    ...(frozen !== undefined ? { frozen } : {}),
+    ...(additional_delegates !== undefined
+      ? { additionalDelegates: additional_delegates }
+      : {}),
+  }))(dasPluginData);
+}
+
+export function dasPluginsToCorePlugins(dasPlugins: Record<string, any>) {
+  return Object.keys(dasPlugins).reduce((acc: PluginsList, dasPluginKey) => {
+    const dasPlugin = dasPlugins[dasPluginKey];
+    const { authority, data, offset } = dasPlugin;
+    const authorityAddress = authority?.address;
+
+    acc = {
+      ...acc,
+      [convertSnakeCase(dasPluginKey)]: {
+        authority: {
+          type: authority.type,
+          ...(authorityAddress ? { address: publicKey(authorityAddress) } : {}),
+        },
+        ...dasPluginDataToCorePluginData(data),
+        offset: BigInt(offset),
+      },
+    };
+
+    return acc;
+  }, {});
+}
+
+function dasAssetToCoreAssetOrCollection(
+  dasAsset: DasApiAsset
+): AssetV1 | CollectionV1 {
+  // TODO: Define types in Umi DAS client.
+  const {
+    interface: assetInterface,
+    id,
+    ownership: { owner },
+    content: {
+      metadata: { name },
+      json_uri: uri,
+    },
+    compression: { seq },
+    grouping,
+    authorities,
+    plugins,
+    executable,
+    lamports: lamps,
+    rent_epoch: rentEpoch,
+    mpl_core_info: mplCoreInfo,
+  } = dasAsset as DasApiAsset & {
+    plugins: Record<string, any>;
+    executable?: boolean;
+    lamports?: number;
+    rent_epoch?: number;
+    mpl_core_info?: {
+      num_minted?: number;
+      current_size?: number;
+      plugins_json_version: number;
+    };
+  };
+  const { num_minted: numMinted = 0, current_size: currentSize = 0 } =
+    mplCoreInfo ?? {};
+  const commonFields = {
+    publicKey: id,
+    uri,
+    name,
+    ...getAccountHeader(executable, lamps, rentEpoch),
+    ...dasPluginsToCorePlugins(plugins),
+    // pluginHeader: // TODO: Reconstruct
+  };
+
+  const isCollection =
+    assetInterface === (MPL_CORE_COLLECTION as DasApiAssetInterface);
+  if (isCollection) {
+    return {
+      ...commonFields,
+      key: Key.CollectionV1,
+      updateAuthority: authorities[0].address,
+      numMinted,
+      currentSize,
+    };
+  }
+
+  return {
+    ...commonFields,
+    key: Key.AssetV1,
+    owner,
+    seq: seq ? some(BigInt(seq)) : none(),
+    ...getUpdateAuthority(grouping[0], authorities[0]),
+  };
+}
+
+async function searchAssets(
+  context: Umi,
+  input: Omit<SearchAssetsRpcInput, 'interface' | 'burnt'> & {
+    interface?: typeof MPL_CORE_ASSET;
+  }
+): Promise<AssetV1[]>;
+async function searchAssets(
+  context: Umi,
+  input: Omit<SearchAssetsRpcInput, 'interface' | 'burnt'> & {
+    interface?: typeof MPL_CORE_COLLECTION;
+  }
+): Promise<CollectionV1[]>;
+async function searchAssets(
+  context: Umi,
+  input: Omit<SearchAssetsRpcInput, 'interface' | 'burnt'> & {
+    interface?: typeof MPL_CORE_ASSET | typeof MPL_CORE_COLLECTION;
+  }
+) {
+  const dasAssets = await context.rpc.searchAssets({
+    ...input,
+    interface: (input.interface ?? MPL_CORE_ASSET) as DasApiAssetInterface,
+    burnt: false,
+  });
+
+  return dasAssets.items.map((dasAsset) =>
+    dasAssetToCoreAssetOrCollection(dasAsset)
+  );
+}
+
+function searchCollections(
+  context: Umi,
+  input: Omit<SearchAssetsRpcInput, 'interface' | 'burnt'>
+) {
+  return searchAssets(context, { ...input, interface: MPL_CORE_COLLECTION });
+}
+
+function fetchAssetsByOwner(
+  context: Umi,
+  input: {
+    owner: PublicKey;
+  } & Pagination
+) {
+  return searchAssets(context, {
+    owner: input.owner,
+  });
+}
+
+function fetchAssetsByAuthority(
+  context: Umi,
+  input: {
+    authority: PublicKey;
+  } & Pagination
+) {
+  return searchAssets(context, {
+    ...input,
+    authority: input.authority,
+  });
+}
+
+function fetchAssetsByCollection(
+  context: Umi,
+  input: {
+    collection: PublicKey;
+  } & Pagination
+) {
+  return searchAssets(context, {
+    ...input,
+    grouping: ['collection', input.collection],
+  });
+}
+
+function fetchCollectionsByUpdateAuthority(
+  context: Umi,
+  input: {
+    updateAuthority: PublicKey;
+  } & Pagination
+) {
+  return searchCollections(context, {
+    ...input,
+    authority: input.updateAuthority,
+  });
+}
+
+export const das = {
+  searchAssets,
+  searchCollections,
+  fetchAssetsByOwner,
+  fetchAssetsByAuthority,
+  fetchAssetsByCollection,
+  fetchCollectionsByUpdateAuthority,
+} as const;

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -6,3 +6,4 @@ export * from './authority';
 export * from './plugins';
 export * from './helpers';
 export * from './instructions';
+export * from './das';

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -1,5 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { createUmi as basecreateUmi } from '@metaplex-foundation/umi-bundle-tests';
+import {
+  createUmi as basecreateUmi,
+  testPlugins,
+} from '@metaplex-foundation/umi-bundle-tests';
 import { Assertions } from 'ava';
 import {
   PublicKey,
@@ -7,7 +10,9 @@ import {
   Umi,
   generateSigner,
   publicKey,
+  createUmi as baseCreateUmi,
 } from '@metaplex-foundation/umi';
+import { dasApi } from '@metaplex-foundation/digital-asset-standard-api';
 import {
   DataState,
   Key,
@@ -24,6 +29,8 @@ import {
 } from '../src';
 
 export const createUmi = async () => (await basecreateUmi()).use(mplCore());
+export const createUmiWithDas = (endpoint: string) =>
+  baseCreateUmi().use(testPlugins(endpoint)).use(dasApi());
 
 export type CreateAssetHelperArgs = {
   owner?: PublicKey | Signer;
@@ -48,6 +55,8 @@ export const DEFAULT_COLLECTION = {
   name: 'Test Collection',
   uri: 'https://example.com/collection',
 };
+
+export const DAS_API_ENDPOINT = process.env.DAS_API_ENDPOINT!;
 
 export const createAsset = async (
   umi: Umi,

--- a/clients/js/test/das/_setup.ts
+++ b/clients/js/test/das/_setup.ts
@@ -1,0 +1,435 @@
+import {
+  generateSigner,
+  createSignerFromKeypair,
+  keypairIdentity,
+  publicKey,
+  Option,
+  PublicKey,
+} from '@metaplex-foundation/umi';
+import { createAsset, createCollection, createUmiWithDas } from '../_setup';
+import {
+  pluginAuthorityPair,
+  AssetV1,
+  Key,
+  ruleSet,
+  addressPluginAuthority,
+  CollectionV1,
+} from '../../src';
+
+const assetCommonData = {
+  name: 'DAS Test Asset',
+  uri: 'https://example.com/das-asset',
+};
+
+function getPluginsForCreation(
+  transferDelegateAuthority: PublicKey,
+  payer: PublicKey
+) {
+  return [
+    pluginAuthorityPair({
+      authority: addressPluginAuthority(transferDelegateAuthority),
+      type: 'TransferDelegate',
+    }),
+    pluginAuthorityPair({
+      type: 'BurnDelegate',
+    }),
+    pluginAuthorityPair({
+      type: 'UpdateDelegate',
+    }),
+    pluginAuthorityPair({
+      type: 'FreezeDelegate',
+      data: { frozen: false },
+    }),
+    pluginAuthorityPair({
+      type: 'Attributes',
+      data: { attributeList: [{ key: 'some key', value: 'some value' }] },
+    }),
+    pluginAuthorityPair({
+      type: 'Royalties',
+      data: {
+        basisPoints: 5,
+        creators: [
+          {
+            address: payer,
+            percentage: 100,
+          },
+        ],
+        ruleSet: ruleSet('None'),
+      },
+    }),
+  ];
+}
+
+// Run this function if assets for DAS tests need to be changed for some reason
+// @ts-ignore
+export async function createDasTestAssetOrCollection({
+  payerSecretKey,
+  rpcEndpoint,
+  isUpdateAuthorityOwner = true,
+  isCollection = false,
+  collection,
+}: {
+  payerSecretKey: Uint8Array;
+  rpcEndpoint: string;
+  isUpdateAuthorityOwner?: boolean;
+  isCollection?: boolean;
+  collection?: PublicKey;
+}) {
+  const umi = createUmiWithDas(rpcEndpoint);
+  const payerKeypair = umi.eddsa.createKeypairFromSecretKey(payerSecretKey);
+  const payer = createSignerFromKeypair(umi, payerKeypair);
+  const assetAddress = generateSigner(umi);
+  const transferDelegateAuthority = generateSigner(umi);
+  const updateAuthority = !isUpdateAuthorityOwner
+    ? generateSigner(umi)
+    : undefined;
+
+  umi.use(keypairIdentity(payerKeypair));
+
+  let asset: AssetV1 | CollectionV1;
+  if (isCollection) {
+    asset = await createCollection(umi, {
+      ...assetCommonData,
+      updateAuthority,
+      collection: assetAddress,
+      payer,
+      plugins: getPluginsForCreation(
+        transferDelegateAuthority.publicKey,
+        payer.publicKey
+      ),
+    });
+  } else {
+    asset = await createAsset(umi, {
+      ...assetCommonData,
+      updateAuthority,
+      asset: assetAddress,
+      payer,
+      collection,
+      plugins: getPluginsForCreation(
+        transferDelegateAuthority.publicKey,
+        payer.publicKey
+      ),
+    });
+  }
+
+  const entity = isCollection ? 'collection' : 'asset';
+  console.log(
+    `A new ${entity} is created. Save the info below somewhere for further use in tests!`
+  );
+  console.log(`Created ${entity}:`, asset);
+}
+
+const testAssetCommonData = {
+  key: Key.AssetV1,
+  seq: { __option: 'None' } as Option<bigint>,
+};
+
+export const dasTestAsset1Owner = publicKey(
+  'EBgC18R6zKNic1CLYKYEy3SMSz4zweymeqrMHkXeqpag'
+);
+export const dasTestAsset1PubKey = publicKey(
+  '8gw7zp8cgo2wwp7wvykXaYvGUS6sHqYZ1PnzyQFW2ANG'
+);
+export const dasTestAsset1: AssetV1 = {
+  ...assetCommonData,
+  ...testAssetCommonData,
+  owner: dasTestAsset1Owner,
+  publicKey: dasTestAsset1PubKey,
+  updateAuthority: {
+    type: 'Address',
+    address: dasTestAsset1Owner,
+  },
+  header: {
+    executable: false,
+    owner: publicKey('CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'),
+    lamports: { basisPoints: 4541520n, identifier: 'SOL', decimals: 9 },
+    rentEpoch: 18446744073709552000,
+    // exists: true,
+  },
+  // pluginHeader: { key: 3, pluginRegistryOffset: 208n },
+  transferDelegate: {
+    authority: {
+      type: 'Address',
+      address: publicKey('3XSp2DSVM99ETD8YrxrytkGVAAu4rE47TJLoD7m3Ww1J'),
+    },
+    offset: 127n,
+  },
+  burnDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 128n,
+  },
+  updateDelegate: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 129n,
+    additionalDelegates: [],
+  },
+  freezeDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 134n,
+    frozen: false,
+  },
+  attributes: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 136n,
+    attributeList: [{ key: 'some key', value: 'some value' }],
+  },
+  royalties: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 167n,
+    basisPoints: 5,
+    creators: [
+      {
+        address: dasTestAsset1Owner,
+        percentage: 100,
+      },
+    ],
+    ruleSet: { __kind: 'None' },
+  },
+};
+
+export const dasTestAsset2PubKey = publicKey(
+  '6wTjNnv5a4QFZDSyVMYaVPSGyAgk9Tppr8Cb3yBjd5th'
+);
+export const dasTestAsset2Owner = dasTestAsset1Owner;
+export const dasTestAsset2UpdateAuthority = publicKey(
+  '7Vrco3r1u1wiBwTm7GZtBmFfVKqVR1tyLn8adUuorQ63'
+);
+export const dasTestAsset2: AssetV1 = {
+  ...assetCommonData,
+  ...testAssetCommonData,
+  owner: dasTestAsset2Owner,
+  publicKey: dasTestAsset2PubKey,
+  updateAuthority: {
+    type: 'Address',
+    address: dasTestAsset2UpdateAuthority,
+  },
+  header: {
+    executable: false,
+    owner: publicKey('CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'),
+    lamports: { basisPoints: 4541520n, identifier: 'SOL', decimals: 9 },
+    rentEpoch: 18446744073709552000,
+    // exists: true,
+  },
+  // pluginHeader: { key: 3, pluginRegistryOffset: 208n },
+  transferDelegate: {
+    authority: {
+      type: 'Address',
+      address: publicKey('7f7w6BVuqHPb1hQgGUfxQP13NjZzF45YUHioUZkdP4Vd'),
+    },
+    offset: 127n,
+  },
+  burnDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 128n,
+  },
+  updateDelegate: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 129n,
+    additionalDelegates: [],
+  },
+  freezeDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 134n,
+    frozen: false,
+  },
+  attributes: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 136n,
+    attributeList: [{ key: 'some key', value: 'some value' }],
+  },
+  royalties: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 167n,
+    basisPoints: 5,
+    creators: [
+      {
+        address: dasTestAsset2Owner,
+        percentage: 100,
+      },
+    ],
+    ruleSet: { __kind: 'None' },
+  },
+};
+
+const testCollectionCommonData = {
+  key: Key.CollectionV1,
+  numMinted: 0,
+  currentSize: 0,
+};
+
+export const dasTestCollection1PubKey = publicKey(
+  '6yNsdZyWiVYzFd56jZe7SjqBwf8UCbv1gbZb3eqyfVSL'
+);
+export const dasTestCollection1: CollectionV1 = {
+  ...assetCommonData,
+  ...testCollectionCommonData,
+  numMinted: 1,
+  currentSize: 1,
+  publicKey: dasTestCollection1PubKey,
+  header: {
+    executable: false,
+    owner: publicKey('CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'),
+    lamports: { basisPoints: 2860560n, identifier: 'SOL', decimals: 9 },
+    rentEpoch: 18446744073709552000,
+    // exists: true,
+  },
+  // pluginHeader: { key: 3, pluginRegistryOffset: 182n },
+  transferDelegate: {
+    authority: {
+      type: 'Address',
+      address: publicKey('A8SQ9q2aRg2SAxJtBQxj8XwWMU74H1R7DYVCyNeYnQFx'),
+    },
+    offset: 101n,
+  },
+  burnDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 102n,
+  },
+  updateDelegate: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 103n,
+    additionalDelegates: [],
+  },
+  freezeDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 108n,
+    frozen: false,
+  },
+  attributes: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 110n,
+    attributeList: [{ key: 'some key', value: 'some value' }],
+  },
+  royalties: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 141n,
+    basisPoints: 5,
+    creators: [
+      {
+        address: dasTestAsset1Owner,
+        percentage: 100,
+      },
+    ],
+    ruleSet: { __kind: 'None' },
+  },
+  updateAuthority: dasTestAsset1Owner,
+};
+
+export const dasTestCollection2PubKey = publicKey(
+  '9g6VQeAn2XUTPyuGXgqZc3YnGJjMxXonhACUy8pCZXLS'
+);
+export const dasTestCollection2UpdateAuthority = publicKey(
+  'UbmPXW4h1P1oNHegWY81a1Q9p7o2Jj5TC4LsUHSUGfm'
+);
+export const dasTestCollection2: CollectionV1 = {
+  ...assetCommonData,
+  ...testCollectionCommonData,
+  publicKey: dasTestCollection2PubKey,
+  header: {
+    executable: false,
+    owner: publicKey('CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'),
+    lamports: { basisPoints: 2860560n, identifier: 'SOL', decimals: 9 },
+    rentEpoch: 18446744073709552000,
+    // exists: true,
+  },
+  // pluginHeader: { key: 3, pluginRegistryOffset: 182n },
+  transferDelegate: {
+    authority: {
+      type: 'Address',
+      address: publicKey('G8xVUAnuYbMFq8pxtWFhUvHC8TVoAkqpWgahizugWFfF'),
+    },
+    offset: 101n,
+  },
+  burnDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 102n,
+  },
+  updateDelegate: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 103n,
+    additionalDelegates: [],
+  },
+  freezeDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 108n,
+    frozen: false,
+  },
+  attributes: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 110n,
+    attributeList: [{ key: 'some key', value: 'some value' }],
+  },
+  royalties: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 141n,
+    basisPoints: 5,
+    creators: [
+      {
+        address: dasTestAsset1Owner,
+        percentage: 100,
+      },
+    ],
+    ruleSet: { __kind: 'None' },
+  },
+  updateAuthority: dasTestCollection2UpdateAuthority,
+};
+
+export const dasTestAssetInCollectionPubKey = publicKey(
+  'CLvNjH92gVevfwBwdabV2WeiqvkWnNBvgy1of64Xvnr3'
+);
+export const dasTestAssetInCollection: AssetV1 = {
+  ...assetCommonData,
+  ...testAssetCommonData,
+  publicKey: dasTestAssetInCollectionPubKey,
+  header: {
+    executable: false,
+    owner: publicKey('CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d'),
+    lamports: { basisPoints: 4541520n, identifier: 'SOL', decimals: 9 },
+    rentEpoch: 18446744073709552000,
+    // exists: true,
+  },
+  // pluginHeader: { key: 3, pluginRegistryOffset: 208n },
+  transferDelegate: {
+    authority: {
+      type: 'Address',
+      address: publicKey('GWxshtvVv5UP3KrRKLVEmfh393gpobKiS3qJHoEt8qf4'),
+    },
+    offset: 127n,
+  },
+  burnDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 128n,
+  },
+  updateDelegate: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 129n,
+    additionalDelegates: [],
+  },
+  freezeDelegate: {
+    authority: { type: 'Owner', address: undefined },
+    offset: 134n,
+    frozen: false,
+  },
+  attributes: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 136n,
+    attributeList: [{ key: 'some key', value: 'some value' }],
+  },
+  royalties: {
+    authority: { type: 'UpdateAuthority', address: undefined },
+    offset: 167n,
+    basisPoints: 5,
+    creators: [
+      {
+        address: dasTestAsset1Owner,
+        percentage: 100,
+      },
+    ],
+    ruleSet: { __kind: 'None' },
+  },
+  owner: dasTestAsset1Owner,
+  updateAuthority: {
+    type: 'Collection',
+    address: dasTestCollection1PubKey,
+  },
+};

--- a/clients/js/test/das/das.test.ts
+++ b/clients/js/test/das/das.test.ts
@@ -1,0 +1,124 @@
+import test from 'ava';
+import { publicKey } from '@metaplex-foundation/umi';
+import { das } from '../../src';
+import { createUmiWithDas, DAS_API_ENDPOINT } from '../_setup';
+import {
+  dasTestAsset1Owner,
+  dasTestAsset1,
+  dasTestAsset2UpdateAuthority,
+  dasTestAsset2,
+  dasTestCollection1,
+  dasTestCollection2UpdateAuthority,
+  dasTestCollection2,
+  dasTestAssetInCollection,
+  dasTestCollection1PubKey,
+  dasTestAsset1PubKey,
+  dasTestAsset2PubKey,
+  dasTestAssetInCollectionPubKey,
+  dasTestCollection2PubKey,
+} from './_setup';
+
+test('das: it can search assets', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then assets are fetched via the MPL Core DAS helper
+  const assets = await das.searchAssets(umi, {
+    owner: dasTestAsset1Owner,
+    interface: 'MplCoreAsset',
+  });
+
+  // The fetched assets structure is the same as with the MPL Core fetchAssetV1
+  const asset = assets.find((a) => a.publicKey === dasTestAsset1PubKey);
+  t.like(asset, dasTestAsset1);
+});
+
+test('das: it can fetch assets by owner', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then assets are fetched via the MPL Core DAS helper
+  const assets = await das.fetchAssetsByOwner(umi, {
+    owner: dasTestAsset1Owner,
+  });
+
+  // The fetched assets structure is the same as with the MPL Core fetchAssetV1
+  const asset = assets.find((a) => a.publicKey === dasTestAsset1PubKey);
+  t.like(asset, dasTestAsset1);
+});
+
+test('das: it can fetch assets by authority', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then assets are fetched via the MPL Core DAS helper
+  const assets = await das.fetchAssetsByAuthority(umi, {
+    authority: dasTestAsset1Owner,
+  });
+
+  // The fetched assets structure is the same as with the MPL Core fetchAssetV1
+  const asset = assets.find((a) => a.publicKey === dasTestAsset1PubKey);
+  t.like(asset, dasTestAsset1);
+});
+
+test('das: it can fetch assets by authority if authority is not owner', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then assets are fetched via the MPL Core DAS helper
+  const assets = await das.fetchAssetsByAuthority(umi, {
+    authority: dasTestAsset2UpdateAuthority,
+  });
+
+  // The fetched assets structure is the same as with the MPL Core fetchAssetV1
+  const asset = assets.find((a) => a.publicKey === dasTestAsset2PubKey);
+  t.like(asset, dasTestAsset2);
+});
+
+test('das: it can fetch assets by collection', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then assets are fetched via the MPL Core DAS helper
+  const assets = await das.fetchAssetsByCollection(umi, {
+    collection: dasTestCollection1PubKey,
+  });
+
+  // The fetched assets structure is the same as with the MPL Core fetchAssetV1
+  const asset = assets.find(
+    (a) => a.publicKey === dasTestAssetInCollectionPubKey
+  );
+  t.like(asset, dasTestAssetInCollection);
+});
+
+test('das: it can fetch collections by update authority', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then collections are fetched via the MPL Core DAS helper
+  const collections = await das.fetchCollectionsByUpdateAuthority(umi, {
+    updateAuthority: publicKey(dasTestAsset1Owner),
+  });
+
+  // One of the fetched collections structure is the same as with the MPL Core fetchCollectionV1
+  const collection = collections.find(
+    (a) => a.publicKey === dasTestCollection1PubKey
+  );
+  t.like(collection, dasTestCollection1);
+});
+
+test('das: it can fetch collections by update authority if update authority is not owner', async (t) => {
+  // Given an Umi instance with DAS API
+  const umi = createUmiWithDas(DAS_API_ENDPOINT);
+
+  // Then collections are fetched via the MPL Core DAS helper
+  const collections = await das.fetchCollectionsByUpdateAuthority(umi, {
+    updateAuthority: publicKey(dasTestCollection2UpdateAuthority),
+  });
+
+  // One of the fetched collections structure is the same as with the MPL Core fetchCollectionV1
+  const collection = collections.find(
+    (a) => a.publicKey === dasTestCollection2PubKey
+  );
+  t.like(collection, dasTestCollection2);
+});


### PR DESCRIPTION
# Description
1. DAS API is added to the JS client
2. DAS assets conversions are implemented
3. A few respective tests are added

# NB!
1. Unknown plugins are not handled yet
2. DAS-related tests are supposably ignored by CI. But this is yet to be tested
3. DAS API endpoint is required in `.env` file in order to make the tests work
4. DAS-related tests do not use `assertAsset` and `assertCollection` because a DAS endpoint can easily return the `Too Many Requests` error
5. TS types should be improved when the DAS client provides new types
