### PR TITLE
Block owner managed plugins on collection create

### DIFF
--- a/clients/js/test/createCollection.test.ts
+++ b/clients/js/test/createCollection.test.ts
@@ -34,13 +34,12 @@ test('it can create a new collection', async (t) => {
 });
 
 test('it can create a new collection with plugins', async (t) => {
-  // Given a Umi instance and a new signer.
   const umi = await createUmi();
 
   const collection = await createCollection(umi, {
     plugins: [
       pluginAuthorityPair({
-        type: 'FreezeDelegate',
+        type: 'PermanentFreezeDelegate',
         data: { frozen: false },
       }),
     ],
@@ -50,9 +49,9 @@ test('it can create a new collection with plugins', async (t) => {
     ...DEFAULT_COLLECTION,
     collection: collection.publicKey,
     updateAuthority: umi.identity.publicKey,
-    freezeDelegate: {
+    permanentFreezeDelegate: {
       authority: {
-        type: 'Owner',
+        type: 'UpdateAuthority',
       },
       frozen: false,
     },
@@ -146,4 +145,23 @@ test('it cannot create a new asset with a collection if it is not the collection
   });
 
   await t.throwsAsync(result, { name: 'InvalidAuthority' });
+});
+
+test('it cannot create a collection with an owner managed plugin', async (t) => {
+  const umi = await createUmi();
+
+  const result = createCollection(umi, {
+    plugins: [
+      pluginAuthorityPair({
+        type: 'FreezeDelegate',
+        data: {
+          frozen: false,
+        }
+      }),
+    ],
+  });
+
+  await t.throwsAsync(result, {
+    name: 'InvalidAuthority',
+  });
 });

--- a/clients/js/test/createCollection.test.ts
+++ b/clients/js/test/createCollection.test.ts
@@ -156,7 +156,7 @@ test('it cannot create a collection with an owner managed plugin', async (t) => 
         type: 'FreezeDelegate',
         data: {
           frozen: false,
-        }
+        },
       }),
     ],
   });

--- a/programs/mpl-core/src/processor/create_collection.rs
+++ b/programs/mpl-core/src/processor/create_collection.rs
@@ -12,7 +12,7 @@ use crate::{
         create_plugin_meta, initialize_plugin, CheckResult, Plugin, PluginAuthorityPair,
         PluginType, ValidationResult,
     },
-    state::{CollectionV1, Key},
+    state::{Authority, CollectionV1, Key},
 };
 
 #[repr(C)]
@@ -90,6 +90,11 @@ pub(crate) fn create_collection<'a>(
             let mut approved = true;
             let mut force_approved = false;
             for plugin in &plugins {
+                // Cannot have owner-managed plugins on collection.
+                if plugin.plugin.manager() == Authority::Owner {
+                    return Err(MplCoreError::InvalidAuthority.into());
+                }
+
                 if PluginType::check_create(&PluginType::from(&plugin.plugin)) != CheckResult::None
                 {
                     match Plugin::validate_create(


### PR DESCRIPTION
Originally i tried to add this to the `Plugin::validate_create` and then inside the individual trait method:
```
fn validate_create(
    &self,
    authority_info: &AccountInfo,
    authority: &Authority,
) -> Result<ValidationResult, ProgramError> {
    Ok(ValidationResult::Pass)
}
```

But I do not believe the `authority_info` and `authority` are enough information to infer whether its being added to a collection.  So to avoid any refactoring I added the check explicitly in the collection create method.