### PR TITLE
Bugfix - dont allow removal of plugins if asset is frozen

### DIFF
--- a/clients/js/test/removePlugin.test.ts
+++ b/clients/js/test/removePlugin.test.ts
@@ -379,3 +379,127 @@ test('it can remove a plugin from asset with existing plugins', async (t) => {
     },
   });
 });
+
+test('it cannot remove a plugin from a frozen asset', async (t) => {
+  const umi = await createUmi();
+
+  const asset = await createAsset(umi, {
+    plugins: [
+      pluginAuthorityPair({
+        type: 'FreezeDelegate',
+        data: { frozen: true },
+      }),
+      pluginAuthorityPair({
+        type: 'TransferDelegate',
+      }),
+      pluginAuthorityPair({
+        type: 'BurnDelegate',
+      }),
+    ],
+  });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Address', address: umi.identity.publicKey },
+    freezeDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+      frozen: true,
+    },
+    transferDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+    burnDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+  });
+
+  const result1 = removePluginV1(umi, {
+    asset: asset.publicKey,
+    pluginType: PluginType.BurnDelegate,
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result1, { name: 'InvalidAuthority' });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Address', address: umi.identity.publicKey },
+    freezeDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+      frozen: true,
+    },
+    transferDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+    burnDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+  });
+});
+
+test('it cannot remove a plugin from an asset with a frozen collection', async (t) => {
+  const umi = await createUmi();
+  const { asset, collection } = await createAssetWithCollection(
+    umi,
+    {
+      plugins: [
+        pluginAuthorityPair({
+          type: 'TransferDelegate',
+        }),
+        pluginAuthorityPair({
+          type: 'BurnDelegate',
+        }),
+      ],
+    },
+    {
+      plugins: [
+        pluginAuthorityPair({
+          type: 'PermanentFreezeDelegate',
+          data: {
+            frozen: true,
+          },
+        }),
+      ],
+    }
+  );
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Collection', address: collection.publicKey },
+    transferDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+    burnDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+  });
+
+  const result = removePluginV1(umi, {
+    asset: asset.publicKey,
+    pluginType: PluginType.TransferDelegate,
+    collection: collection.publicKey,
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'InvalidAuthority' });
+});

--- a/programs/mpl-core/src/plugins/freeze_delegate.rs
+++ b/programs/mpl-core/src/plugins/freeze_delegate.rs
@@ -108,10 +108,7 @@ impl PluginValidation for FreezeDelegate {
         _authority: &Authority,
         plugin_to_revoke: Option<&Plugin>,
     ) -> Result<ValidationResult, ProgramError> {
-        if plugin_to_revoke.is_some()
-            && PluginType::from(plugin_to_revoke.unwrap()) == PluginType::FreezeDelegate
-            && self.frozen
-        {
+        if plugin_to_revoke.is_some() && self.frozen {
             Ok(ValidationResult::Rejected)
         } else {
             Ok(ValidationResult::Pass)

--- a/programs/mpl-core/src/plugins/permanent_freeze_delegate.rs
+++ b/programs/mpl-core/src/plugins/permanent_freeze_delegate.rs
@@ -112,10 +112,7 @@ impl PluginValidation for PermanentFreezeDelegate {
         _authority: &Authority,
         plugin_to_revoke: Option<&Plugin>,
     ) -> Result<ValidationResult, ProgramError> {
-        if plugin_to_revoke.is_some()
-            && PluginType::from(plugin_to_revoke.unwrap()) == PluginType::PermanentFreezeDelegate
-            && self.frozen
-        {
+        if plugin_to_revoke.is_some() && self.frozen {
             Ok(ValidationResult::Rejected)
         } else {
             Ok(ValidationResult::Pass)


### PR DESCRIPTION
If an asset is frozen, no plugins should be removed until the asset is unfrozen. Use cases that are broken because of this functionality include non-custodial marketplaces and loans, as the holder can approve trransfer and freeze auth, the program can freeze the asset, then the user can remove the transfer auth, meaning the program is not able to transfer the asset.

* Updated freeze delegate check that was only denying the removal of the FreezeDelegate plugin
* Made the same change to PermanentFreezeDelegate

There are some other functions that should probably be denied if an asset is frozen as they result in unusual behaviour - eg you can add a freeze delegate and freeze an asset with permanent transfer auth, then transfer it while frozen. This should be addressed in a separate PR