### PR TITLE
Bugfix - allow collections to be burnt

### DIFF
--- a/programs/mpl-core/src/processor/burn.rs
+++ b/programs/mpl-core/src/processor/burn.rs
@@ -114,9 +114,9 @@ pub(crate) fn burn_collection<'a>(
         authority,
         ctx.accounts.collection,
         None,
-        CollectionV1::check_burn,
+        CollectionV1::check_self_burn,
         PluginType::check_burn,
-        CollectionV1::validate_burn,
+        CollectionV1::validate_self_burn,
         Plugin::validate_burn,
     )?;
 

--- a/programs/mpl-core/src/state/collection.rs
+++ b/programs/mpl-core/src/state/collection.rs
@@ -83,6 +83,11 @@ impl CollectionV1 {
         CheckResult::None
     }
 
+    /// Check permissions for the burn lifecycle event.
+    pub fn check_self_burn() -> CheckResult {
+        CheckResult::CanApprove
+    }
+
     /// Check permissions for the update lifecycle event.
     pub fn check_update() -> CheckResult {
         CheckResult::CanApprove
@@ -203,6 +208,19 @@ impl CollectionV1 {
         _: Option<&Plugin>,
     ) -> Result<ValidationResult, ProgramError> {
         Ok(ValidationResult::Pass)
+    }
+
+    /// Validate the self-burn lifecycle event.
+    pub fn validate_self_burn(
+        &self,
+        authority_info: &AccountInfo,
+        _: Option<&Plugin>,
+    ) -> Result<ValidationResult, ProgramError> {
+        if self.current_size == 0 && authority_info.key == &self.update_authority {
+            Ok(ValidationResult::Approved)
+        } else {
+            Ok(ValidationResult::Rejected)
+        }
     }
 
     /// Validate the update lifecycle event.


### PR DESCRIPTION
Currently collections cannot be burned due to the burn lifecycle event on a collection not adding any approval

* added new burn_self lifecycle event
* fail if not update authority
* fail if current size != 0 - this would result in an inconsistent state