### PR TITLE
Bugfix - dont allow assets to be removed from a collection

### DIFF
--- a/clients/js/test/update.test.ts
+++ b/clients/js/test/update.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   assertAsset,
   createAsset,
+  createAssetWithCollection,
   createCollection,
   createUmi,
   DEFAULT_ASSET,
@@ -193,6 +194,22 @@ test('it cannot update an asset update authority to be part of a collection (rig
     newUpdateAuthority: updateAuthority('Collection', [
       newCollection.publicKey,
     ]),
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'NotAvailable' });
+});
+
+test('it cannot remove an asset from a collection (right now)', async (t) => {
+  // Given a Umi instance and a new signer.
+  const umi = await createUmi();
+  const { asset, collection } = await createAssetWithCollection(umi, {}, {});
+
+  const result = updateV1(umi, {
+    asset: asset.publicKey,
+    newName: 'Test Bread 2',
+    newUri: 'https://example.com/bread2',
+    collection: collection.publicKey,
+    newUpdateAuthority: updateAuthority('Address', [umi.identity.publicKey]),
   }).sendAndConfirm(umi);
 
   await t.throwsAsync(result, { name: 'NotAvailable' });

--- a/programs/mpl-core/src/processor/update.rs
+++ b/programs/mpl-core/src/processor/update.rs
@@ -72,6 +72,12 @@ pub(crate) fn update<'a>(accounts: &'a [AccountInfo<'a>], args: UpdateV1Args) ->
             return Err(MplCoreError::NotAvailable.into());
         };
 
+        if let UpdateAuthority::Collection(_collection_address) = asset.update_authority {
+            // Removing from collection is not currently available.
+            // will require the collection size to be updated
+            return Err(MplCoreError::NotAvailable.into());
+        }
+
         asset.update_authority = new_update_authority;
         dirty = true;
     }


### PR DESCRIPTION
Currently there is a check to ensure assets cannot be added to a collection using the update instruction, however this doesn't extent to removing from a collection

An asset can be removed from a collection by updating the update_authority of the asset, which results in inconsistent state as the collection size isn't updated