### PR TITLE
Fix removing collection plugin checks

### DIFF
--- a/clients/js/test/plugins/collection/permanentBurn.test.ts
+++ b/clients/js/test/plugins/collection/permanentBurn.test.ts
@@ -4,6 +4,8 @@ import {
   updatePluginAuthority,
   addCollectionPluginV1,
   createPlugin,
+  removeCollectionPluginV1,
+  PluginType,
 } from '../../../src';
 import {
   DEFAULT_COLLECTION,
@@ -51,6 +53,40 @@ test('it cannot add permanentBurnDelegate to collection after creation', async (
   await t.throwsAsync(result, {
     name: 'InvalidAuthority',
   });
+
+  await assertCollection(t, umi, {
+    ...DEFAULT_COLLECTION,
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    permanentBurnDelegate: undefined,
+  });
+});
+
+test('it can remove permanentBurnDelegate from collection', async (t) => {
+  const umi = await createUmi();
+  const collection = await createCollection(umi, {
+    plugins: [
+      pluginAuthorityPair({
+        type: 'PermanentBurnDelegate',
+      }),
+    ],
+  });
+
+  await assertCollection(t, umi, {
+    ...DEFAULT_COLLECTION,
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    permanentBurnDelegate: {
+      authority: {
+        type: 'UpdateAuthority',
+      },
+    },
+  });
+
+  await removeCollectionPluginV1(umi, {
+    collection: collection.publicKey,
+    pluginType: PluginType.PermanentBurnDelegate,
+  }).sendAndConfirm(umi);
 
   await assertCollection(t, umi, {
     ...DEFAULT_COLLECTION,

--- a/clients/js/test/plugins/collection/permanentFreeze.test.ts
+++ b/clients/js/test/plugins/collection/permanentFreeze.test.ts
@@ -97,7 +97,7 @@ test('it cannot remove permanentFreezeDelegate from collection when frozen', asy
     },
   });
 
-  let result = removeCollectionPluginV1(umi, {
+  const result = removeCollectionPluginV1(umi, {
     collection: collection.publicKey,
     pluginType: PluginType.PermanentFreezeDelegate,
   }).sendAndConfirm(umi);

--- a/clients/js/test/plugins/collection/permanentFreeze.test.ts
+++ b/clients/js/test/plugins/collection/permanentFreeze.test.ts
@@ -14,7 +14,7 @@ import {
   createUmi,
 } from '../../_setup';
 
-test('it can add permanent freeze to collection', async (t) => {
+test('it can add permanentFreezeDelegate to collection', async (t) => {
   const umi = await createUmi();
   const collection = await createCollection(umi, {
     plugins: [
@@ -38,7 +38,7 @@ test('it can add permanent freeze to collection', async (t) => {
   });
 });
 
-test('it can remove permanent freeze from collection', async (t) => {
+test('it can remove permanentFreezeDelegate from collection', async (t) => {
   const umi = await createUmi();
   const collection = await createCollection(umi, {
     plugins: [
@@ -74,7 +74,7 @@ test('it can remove permanent freeze from collection', async (t) => {
   });
 });
 
-test('it cannot remove permanent freeze from collection when frozen', async (t) => {
+test('it cannot remove permanentFreezeDelegate from collection when frozen', async (t) => {
   const umi = await createUmi();
   const collection = await createCollection(umi, {
     plugins: [
@@ -119,7 +119,7 @@ test('it cannot remove permanent freeze from collection when frozen', async (t) 
   });
 });
 
-test('it cannot add permanentFreeze to collection after creation', async (t) => {
+test('it cannot add permanentFreezeDelegate to collection after creation', async (t) => {
   const umi = await createUmi();
 
   const collection = await createCollection(umi);

--- a/clients/js/test/plugins/collection/permanentTransfer.test.ts
+++ b/clients/js/test/plugins/collection/permanentTransfer.test.ts
@@ -5,8 +5,15 @@ import {
   createPlugin,
   pluginAuthorityPair,
   updatePluginAuthority,
+  removeCollectionPluginV1,
+  PluginType,
 } from '../../../src';
-import { assertCollection, createCollection, createUmi } from '../../_setup';
+import {
+  assertCollection,
+  createCollection,
+  createUmi,
+  DEFAULT_COLLECTION,
+} from '../../_setup';
 
 test('it can add permanentTransferDelegate to collection', async (t) => {
   const umi = await createUmi();
@@ -21,7 +28,7 @@ test('it can add permanentTransferDelegate to collection', async (t) => {
   });
 
   await assertCollection(t, umi, {
-    ...collection,
+    ...DEFAULT_COLLECTION,
     collection: collection.publicKey,
     updateAuthority: umi.identity.publicKey,
     permanentTransferDelegate: {
@@ -49,7 +56,41 @@ test('it cannot add PermanentTransferDelegate to collection after creation', asy
   });
 
   await assertCollection(t, umi, {
-    ...collection,
+    ...DEFAULT_COLLECTION,
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    permanentTransferDelegate: undefined,
+  });
+});
+
+test('it can remove PermanentTransferDelegate from collection', async (t) => {
+  const umi = await createUmi();
+  const collection = await createCollection(umi, {
+    plugins: [
+      pluginAuthorityPair({
+        type: 'PermanentTransferDelegate',
+      }),
+    ],
+  });
+
+  await assertCollection(t, umi, {
+    ...DEFAULT_COLLECTION,
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    permanentTransferDelegate: {
+      authority: {
+        type: 'UpdateAuthority',
+      },
+    },
+  });
+
+  await removeCollectionPluginV1(umi, {
+    collection: collection.publicKey,
+    pluginType: PluginType.PermanentTransferDelegate,
+  }).sendAndConfirm(umi);
+
+  await assertCollection(t, umi, {
+    ...DEFAULT_COLLECTION,
     collection: collection.publicKey,
     updateAuthority: umi.identity.publicKey,
     permanentTransferDelegate: undefined,

--- a/programs/mpl-core/src/plugins/freeze_delegate.rs
+++ b/programs/mpl-core/src/plugins/freeze_delegate.rs
@@ -3,7 +3,7 @@ use solana_program::{account_info::AccountInfo, program_error::ProgramError};
 
 use crate::state::{Authority, DataBlob};
 
-use super::{Plugin, PluginType, PluginValidation, ValidationResult};
+use super::{Plugin, PluginValidation, ValidationResult};
 
 /// The freeze delegate plugin allows any authority to lock the asset so it's no longer transferable.
 /// The default authority for this plugin is the owner.

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -32,6 +32,7 @@ impl PluginType {
             PluginType::UpdateDelegate => CheckResult::CanApprove,
             PluginType::PermanentFreezeDelegate => CheckResult::CanReject,
             PluginType::PermanentTransferDelegate => CheckResult::CanReject,
+            PluginType::PermanentBurnDelegate => CheckResult::CanReject,
             _ => CheckResult::None,
         }
     }

--- a/programs/mpl-core/src/processor/remove_plugin.rs
+++ b/programs/mpl-core/src/processor/remove_plugin.rs
@@ -124,10 +124,10 @@ pub(crate) fn remove_collection_plugin<'a>(
         authority,
         ctx.accounts.collection,
         Some(&plugin_to_remove),
-        CollectionV1::check_add_plugin,
-        PluginType::check_add_plugin,
-        CollectionV1::validate_add_plugin,
-        Plugin::validate_add_plugin,
+        CollectionV1::check_remove_plugin,
+        PluginType::check_remove_plugin,
+        CollectionV1::validate_remove_plugin,
+        Plugin::validate_remove_plugin,
     )?;
 
     process_remove_plugin(


### PR DESCRIPTION
Also add a few tests, some of which fail without this change.
Also add a missing `permanentBurnDelegate` check.