### PR TITLE
Move key information into init structs

### DIFF
--- a/clients/js/src/generated/instructions/addCollectionExternalPluginV1.ts
+++ b/clients/js/src/generated/instructions/addCollectionExternalPluginV1.ts
@@ -28,10 +28,7 @@ import {
 import {
   ExternalPluginInitInfo,
   ExternalPluginInitInfoArgs,
-  ExternalPluginKey,
-  ExternalPluginKeyArgs,
   getExternalPluginInitInfoSerializer,
-  getExternalPluginKeySerializer,
 } from '../types';
 
 // Accounts.
@@ -51,12 +48,10 @@ export type AddCollectionExternalPluginV1InstructionAccounts = {
 // Data.
 export type AddCollectionExternalPluginV1InstructionData = {
   discriminator: number;
-  key: ExternalPluginKey;
   initInfo: ExternalPluginInitInfo;
 };
 
 export type AddCollectionExternalPluginV1InstructionDataArgs = {
-  key: ExternalPluginKeyArgs;
   initInfo: ExternalPluginInitInfoArgs;
 };
 
@@ -72,7 +67,6 @@ export function getAddCollectionExternalPluginV1InstructionDataSerializer(): Ser
     struct<AddCollectionExternalPluginV1InstructionData>(
       [
         ['discriminator', u8()],
-        ['key', getExternalPluginKeySerializer()],
         ['initInfo', getExternalPluginInitInfoSerializer()],
       ],
       { description: 'AddCollectionExternalPluginV1InstructionData' }

--- a/clients/js/src/generated/instructions/addExternalPluginV1.ts
+++ b/clients/js/src/generated/instructions/addExternalPluginV1.ts
@@ -28,10 +28,7 @@ import {
 import {
   ExternalPluginInitInfo,
   ExternalPluginInitInfoArgs,
-  ExternalPluginKey,
-  ExternalPluginKeyArgs,
   getExternalPluginInitInfoSerializer,
-  getExternalPluginKeySerializer,
 } from '../types';
 
 // Accounts.
@@ -53,12 +50,10 @@ export type AddExternalPluginV1InstructionAccounts = {
 // Data.
 export type AddExternalPluginV1InstructionData = {
   discriminator: number;
-  key: ExternalPluginKey;
   initInfo: ExternalPluginInitInfo;
 };
 
 export type AddExternalPluginV1InstructionDataArgs = {
-  key: ExternalPluginKeyArgs;
   initInfo: ExternalPluginInitInfoArgs;
 };
 
@@ -74,7 +69,6 @@ export function getAddExternalPluginV1InstructionDataSerializer(): Serializer<
     struct<AddExternalPluginV1InstructionData>(
       [
         ['discriminator', u8()],
-        ['key', getExternalPluginKeySerializer()],
         ['initInfo', getExternalPluginInitInfoSerializer()],
       ],
       { description: 'AddExternalPluginV1InstructionData' }

--- a/clients/js/src/generated/types/dataStoreInitInfo.ts
+++ b/clients/js/src/generated/types/dataStoreInitInfo.ts
@@ -32,14 +32,16 @@ import {
 } from '.';
 
 export type DataStoreInitInfo = {
-  initAuthority: Option<PluginAuthority>;
+  dataAuthority: PluginAuthority;
+  initPluginAuthority: Option<PluginAuthority>;
   lifecycleChecks: Option<Array<[HookableLifecycleEvent, ExternalCheckResult]>>;
   schema: Option<ExternalPluginSchema>;
   data: Option<Uint8Array>;
 };
 
 export type DataStoreInitInfoArgs = {
-  initAuthority: OptionOrNullable<PluginAuthorityArgs>;
+  dataAuthority: PluginAuthorityArgs;
+  initPluginAuthority: OptionOrNullable<PluginAuthorityArgs>;
   lifecycleChecks: OptionOrNullable<
     Array<[HookableLifecycleEventArgs, ExternalCheckResultArgs]>
   >;
@@ -53,7 +55,8 @@ export function getDataStoreInitInfoSerializer(): Serializer<
 > {
   return struct<DataStoreInitInfo>(
     [
-      ['initAuthority', option(getPluginAuthoritySerializer())],
+      ['dataAuthority', getPluginAuthoritySerializer()],
+      ['initPluginAuthority', option(getPluginAuthoritySerializer())],
       [
         'lifecycleChecks',
         option(

--- a/clients/js/src/generated/types/lifecycleHookInitInfo.ts
+++ b/clients/js/src/generated/types/lifecycleHookInitInfo.ts
@@ -6,12 +6,13 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Option, OptionOrNullable } from '@metaplex-foundation/umi';
+import { Option, OptionOrNullable, PublicKey } from '@metaplex-foundation/umi';
 import {
   Serializer,
   array,
   bytes,
   option,
+  publicKey as publicKeySerializer,
   struct,
   tuple,
   u32,
@@ -35,7 +36,8 @@ import {
 } from '.';
 
 export type LifecycleHookInitInfo = {
-  initAuthority: Option<PluginAuthority>;
+  hookedProgram: PublicKey;
+  initPluginAuthority: Option<PluginAuthority>;
   lifecycleChecks: Option<Array<[HookableLifecycleEvent, ExternalCheckResult]>>;
   extraAccounts: Option<Array<ExtraAccount>>;
   schema: Option<ExternalPluginSchema>;
@@ -43,7 +45,8 @@ export type LifecycleHookInitInfo = {
 };
 
 export type LifecycleHookInitInfoArgs = {
-  initAuthority: OptionOrNullable<PluginAuthorityArgs>;
+  hookedProgram: PublicKey;
+  initPluginAuthority: OptionOrNullable<PluginAuthorityArgs>;
   lifecycleChecks: OptionOrNullable<
     Array<[HookableLifecycleEventArgs, ExternalCheckResultArgs]>
   >;
@@ -58,7 +61,8 @@ export function getLifecycleHookInitInfoSerializer(): Serializer<
 > {
   return struct<LifecycleHookInitInfo>(
     [
-      ['initAuthority', option(getPluginAuthoritySerializer())],
+      ['hookedProgram', publicKeySerializer()],
+      ['initPluginAuthority', option(getPluginAuthoritySerializer())],
       [
         'lifecycleChecks',
         option(

--- a/clients/js/src/generated/types/oracleInitInfo.ts
+++ b/clients/js/src/generated/types/oracleInitInfo.ts
@@ -6,11 +6,12 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
-import { Option, OptionOrNullable } from '@metaplex-foundation/umi';
+import { Option, OptionOrNullable, PublicKey } from '@metaplex-foundation/umi';
 import {
   Serializer,
   array,
   option,
+  publicKey as publicKeySerializer,
   struct,
   tuple,
 } from '@metaplex-foundation/umi/serializers';
@@ -30,13 +31,15 @@ import {
 } from '.';
 
 export type OracleInitInfo = {
-  initAuthority: Option<PluginAuthority>;
+  baseAddress: PublicKey;
+  initPluginAuthority: Option<PluginAuthority>;
   lifecycleChecks: Option<Array<[HookableLifecycleEvent, ExternalCheckResult]>>;
   pda: Option<ExtraAccount>;
 };
 
 export type OracleInitInfoArgs = {
-  initAuthority: OptionOrNullable<PluginAuthorityArgs>;
+  baseAddress: PublicKey;
+  initPluginAuthority: OptionOrNullable<PluginAuthorityArgs>;
   lifecycleChecks: OptionOrNullable<
     Array<[HookableLifecycleEventArgs, ExternalCheckResultArgs]>
   >;
@@ -49,7 +52,8 @@ export function getOracleInitInfoSerializer(): Serializer<
 > {
   return struct<OracleInitInfo>(
     [
-      ['initAuthority', option(getPluginAuthoritySerializer())],
+      ['baseAddress', publicKeySerializer()],
+      ['initPluginAuthority', option(getPluginAuthoritySerializer())],
       [
         'lifecycleChecks',
         option(

--- a/clients/rust/src/generated/instructions/add_collection_external_plugin_v1.rs
+++ b/clients/rust/src/generated/instructions/add_collection_external_plugin_v1.rs
@@ -6,7 +6,6 @@
 //!
 
 use crate::generated::types::ExternalPluginInitInfo;
-use crate::generated::types::ExternalPluginKey;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -99,7 +98,6 @@ impl AddCollectionExternalPluginV1InstructionData {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddCollectionExternalPluginV1InstructionArgs {
-    pub key: ExternalPluginKey,
     pub init_info: ExternalPluginInitInfo,
 }
 
@@ -119,7 +117,6 @@ pub struct AddCollectionExternalPluginV1Builder {
     authority: Option<solana_program::pubkey::Pubkey>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     log_wrapper: Option<solana_program::pubkey::Pubkey>,
-    key: Option<ExternalPluginKey>,
     init_info: Option<ExternalPluginInitInfo>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
@@ -165,11 +162,6 @@ impl AddCollectionExternalPluginV1Builder {
         self
     }
     #[inline(always)]
-    pub fn key(&mut self, key: ExternalPluginKey) -> &mut Self {
-        self.key = Some(key);
-        self
-    }
-    #[inline(always)]
     pub fn init_info(&mut self, init_info: ExternalPluginInitInfo) -> &mut Self {
         self.init_info = Some(init_info);
         self
@@ -204,7 +196,6 @@ impl AddCollectionExternalPluginV1Builder {
             log_wrapper: self.log_wrapper,
         };
         let args = AddCollectionExternalPluginV1InstructionArgs {
-            key: self.key.clone().expect("key is not set"),
             init_info: self.init_info.clone().expect("init_info is not set"),
         };
 
@@ -391,7 +382,6 @@ impl<'a, 'b> AddCollectionExternalPluginV1CpiBuilder<'a, 'b> {
             authority: None,
             system_program: None,
             log_wrapper: None,
-            key: None,
             init_info: None,
             __remaining_accounts: Vec::new(),
         });
@@ -442,11 +432,6 @@ impl<'a, 'b> AddCollectionExternalPluginV1CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn key(&mut self, key: ExternalPluginKey) -> &mut Self {
-        self.instruction.key = Some(key);
-        self
-    }
-    #[inline(always)]
     pub fn init_info(&mut self, init_info: ExternalPluginInitInfo) -> &mut Self {
         self.instruction.init_info = Some(init_info);
         self
@@ -493,7 +478,6 @@ impl<'a, 'b> AddCollectionExternalPluginV1CpiBuilder<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
         let args = AddCollectionExternalPluginV1InstructionArgs {
-            key: self.instruction.key.clone().expect("key is not set"),
             init_info: self
                 .instruction
                 .init_info
@@ -531,7 +515,6 @@ struct AddCollectionExternalPluginV1CpiBuilderInstruction<'a, 'b> {
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     log_wrapper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    key: Option<ExternalPluginKey>,
     init_info: Option<ExternalPluginInitInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(

--- a/clients/rust/src/generated/instructions/add_external_plugin_v1.rs
+++ b/clients/rust/src/generated/instructions/add_external_plugin_v1.rs
@@ -6,7 +6,6 @@
 //!
 
 use crate::generated::types::ExternalPluginInitInfo;
-use crate::generated::types::ExternalPluginKey;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -110,7 +109,6 @@ impl AddExternalPluginV1InstructionData {
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddExternalPluginV1InstructionArgs {
-    pub key: ExternalPluginKey,
     pub init_info: ExternalPluginInitInfo,
 }
 
@@ -132,7 +130,6 @@ pub struct AddExternalPluginV1Builder {
     authority: Option<solana_program::pubkey::Pubkey>,
     system_program: Option<solana_program::pubkey::Pubkey>,
     log_wrapper: Option<solana_program::pubkey::Pubkey>,
-    key: Option<ExternalPluginKey>,
     init_info: Option<ExternalPluginInitInfo>,
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
@@ -185,11 +182,6 @@ impl AddExternalPluginV1Builder {
         self
     }
     #[inline(always)]
-    pub fn key(&mut self, key: ExternalPluginKey) -> &mut Self {
-        self.key = Some(key);
-        self
-    }
-    #[inline(always)]
     pub fn init_info(&mut self, init_info: ExternalPluginInitInfo) -> &mut Self {
         self.init_info = Some(init_info);
         self
@@ -225,7 +217,6 @@ impl AddExternalPluginV1Builder {
             log_wrapper: self.log_wrapper,
         };
         let args = AddExternalPluginV1InstructionArgs {
-            key: self.key.clone().expect("key is not set"),
             init_info: self.init_info.clone().expect("init_info is not set"),
         };
 
@@ -433,7 +424,6 @@ impl<'a, 'b> AddExternalPluginV1CpiBuilder<'a, 'b> {
             authority: None,
             system_program: None,
             log_wrapper: None,
-            key: None,
             init_info: None,
             __remaining_accounts: Vec::new(),
         });
@@ -491,11 +481,6 @@ impl<'a, 'b> AddExternalPluginV1CpiBuilder<'a, 'b> {
         self
     }
     #[inline(always)]
-    pub fn key(&mut self, key: ExternalPluginKey) -> &mut Self {
-        self.instruction.key = Some(key);
-        self
-    }
-    #[inline(always)]
     pub fn init_info(&mut self, init_info: ExternalPluginInitInfo) -> &mut Self {
         self.instruction.init_info = Some(init_info);
         self
@@ -542,7 +527,6 @@ impl<'a, 'b> AddExternalPluginV1CpiBuilder<'a, 'b> {
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
         let args = AddExternalPluginV1InstructionArgs {
-            key: self.instruction.key.clone().expect("key is not set"),
             init_info: self
                 .instruction
                 .init_info
@@ -583,7 +567,6 @@ struct AddExternalPluginV1CpiBuilderInstruction<'a, 'b> {
     authority: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     system_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     log_wrapper: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    key: Option<ExternalPluginKey>,
     init_info: Option<ExternalPluginInitInfo>,
     /// Additional instruction accounts `(AccountInfo, is_writable, is_signer)`.
     __remaining_accounts: Vec<(

--- a/clients/rust/src/generated/types/data_store_init_info.rs
+++ b/clients/rust/src/generated/types/data_store_init_info.rs
@@ -15,7 +15,8 @@ use borsh::BorshSerialize;
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DataStoreInitInfo {
-    pub init_authority: Option<PluginAuthority>,
+    pub data_authority: PluginAuthority,
+    pub init_plugin_authority: Option<PluginAuthority>,
     pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
     pub schema: Option<ExternalPluginSchema>,
     pub data: Option<Vec<u8>>,

--- a/clients/rust/src/generated/types/lifecycle_hook_init_info.rs
+++ b/clients/rust/src/generated/types/lifecycle_hook_init_info.rs
@@ -12,11 +12,17 @@ use crate::generated::types::HookableLifecycleEvent;
 use crate::generated::types::PluginAuthority;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
+use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LifecycleHookInitInfo {
-    pub init_authority: Option<PluginAuthority>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
+    pub hooked_program: Pubkey,
+    pub init_plugin_authority: Option<PluginAuthority>,
     pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
     pub extra_accounts: Option<Vec<ExtraAccount>>,
     pub schema: Option<ExternalPluginSchema>,

--- a/clients/rust/src/generated/types/oracle_init_info.rs
+++ b/clients/rust/src/generated/types/oracle_init_info.rs
@@ -11,11 +11,17 @@ use crate::generated::types::HookableLifecycleEvent;
 use crate::generated::types::PluginAuthority;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
+use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OracleInitInfo {
-    pub init_authority: Option<PluginAuthority>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
+    pub base_address: Pubkey,
+    pub init_plugin_authority: Option<PluginAuthority>,
     pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
     pub pda: Option<ExtraAccount>,
 }

--- a/idls/mpl_core.json
+++ b/idls/mpl_core.json
@@ -2021,7 +2021,13 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "initAuthority",
+            "name": "dataAuthority",
+            "type": {
+              "defined": "Authority"
+            }
+          },
+          {
+            "name": "initPluginAuthority",
             "type": {
               "option": {
                 "defined": "Authority"
@@ -2157,7 +2163,11 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "initAuthority",
+            "name": "hookedProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "initPluginAuthority",
             "type": {
               "option": {
                 "defined": "Authority"
@@ -2273,7 +2283,11 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "initAuthority",
+            "name": "baseAddress",
+            "type": "publicKey"
+          },
+          {
+            "name": "initPluginAuthority",
             "type": {
               "option": {
                 "defined": "Authority"
@@ -2501,12 +2515,6 @@
         "kind": "struct",
         "fields": [
           {
-            "name": "key",
-            "type": {
-              "defined": "ExternalPluginKey"
-            }
-          },
-          {
             "name": "initInfo",
             "type": {
               "defined": "ExternalPluginInitInfo"
@@ -2520,12 +2528,6 @@
       "type": {
         "kind": "struct",
         "fields": [
-          {
-            "name": "key",
-            "type": {
-              "defined": "ExternalPluginKey"
-            }
-          },
           {
             "name": "initInfo",
             "type": {

--- a/programs/mpl-core/src/plugins/data_store.rs
+++ b/programs/mpl-core/src/plugins/data_store.rs
@@ -18,8 +18,11 @@ pub struct DataStore {
 /// Data store initialization info.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, Eq, PartialEq)]
 pub struct DataStoreInitInfo {
-    /// Initial authority.
-    pub init_authority: Option<Authority>,
+    /// Data authority who can update the data store.  Cannot be changed after plugin is
+    /// added.
+    pub data_authority: Authority,
+    /// Initial plugin authority who can update plugin properties.
+    pub init_plugin_authority: Option<Authority>,
     /// The lifecyle events for which the the external plugin is active.
     pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
     /// Schema for the data used by the plugin.

--- a/programs/mpl-core/src/plugins/lifecycle_hook.rs
+++ b/programs/mpl-core/src/plugins/lifecycle_hook.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
 
 use super::{
     Authority, ExternalCheckResult, ExternalPluginSchema, ExtraAccount, HookableLifecycleEvent,
@@ -26,8 +27,10 @@ pub struct LifecycleHook {
 /// Lifecycle hook initialization info.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, Eq, PartialEq)]
 pub struct LifecycleHookInitInfo {
-    /// Initial authority.
-    pub init_authority: Option<Authority>,
+    /// The `Pubkey` for the hooked program.
+    pub hooked_program: Pubkey,
+    /// Initial plugin authority.
+    pub init_plugin_authority: Option<Authority>,
     /// The lifecyle events for which the the external plugin is active.
     pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
     /// The extra accounts to use for the lifecycle hook.

--- a/programs/mpl-core/src/plugins/oracle.rs
+++ b/programs/mpl-core/src/plugins/oracle.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
 
 use super::{Authority, ExternalCheckResult, ExtraAccount, HookableLifecycleEvent};
 
@@ -15,8 +16,11 @@ pub struct Oracle {
 /// Oracle initialization info.
 #[derive(Clone, Debug, BorshSerialize, BorshDeserialize, Eq, PartialEq)]
 pub struct OracleInitInfo {
-    /// Initial authority.
-    pub init_authority: Option<Authority>,
+    /// The address of the oracle, or if using the `pda` option, a program ID from which
+    /// to derive a PDA.
+    pub base_address: Pubkey,
+    /// Initial plugin authority.
+    pub init_plugin_authority: Option<Authority>,
     /// The lifecyle events for which the the external plugin is active.
     pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
     /// Optional PDA (derived from Pubkey attached to `ExternalPluginKey`).

--- a/programs/mpl-core/src/processor/add_external_plugin.rs
+++ b/programs/mpl-core/src/processor/add_external_plugin.rs
@@ -1,16 +1,11 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult};
 
-use crate::{
-    error::MplCoreError,
-    plugins::{ExternalPluginInitInfo, ExternalPluginKey},
-};
+use crate::{error::MplCoreError, plugins::ExternalPluginInitInfo};
 
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub(crate) struct AddExternalPluginV1Args {
-    /// External plugin key.
-    pub key: ExternalPluginKey,
     /// External plugin initialization info.
     pub init_info: ExternalPluginInitInfo,
 }
@@ -25,8 +20,6 @@ pub(crate) fn add_external_plugin<'a>(
 #[repr(C)]
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Debug, Clone)]
 pub(crate) struct AddCollectionExternalPluginV1Args {
-    /// External plugin key.
-    pub key: ExternalPluginKey,
     /// External plugin initialization info.
     pub init_info: ExternalPluginInitInfo,
 }


### PR DESCRIPTION
Option B (not in this PR) would be for `createV2` to take a tuple, which would have the benefit of letting `add_external_plugin`, `remove_external_plugin`, and `update_external_plugin` consistently all require an `ExternalPluginKey`:
```
pub(crate) struct CreateV2Args {
    ...
    pub(crate) external_plugins: Option<Vec<(ExternalPluginKey, ExternalPluginInitInfo)>>,
}
```