### PR TITLE
Incorrect Authority::None check

### DIFF
--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -228,7 +228,11 @@ impl Plugin {
         plugin: &Plugin,
         ctx: &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority == &Authority::None {
+        // If the plugin being checked is Authority::None then it can't be revoked.
+        if ctx.self_authority == &Authority::None
+            && ctx.target_plugin.is_some()
+            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::from(plugin)
+        {
             solana_program::msg!("Base: Rejected");
             return Ok(ValidationResult::Rejected);
         }


### PR DESCRIPTION
Fixing a bug that prevented revoking any plugin when one had Authority::None.