### PR TITLE
Add external plugin validation functions 

### DIFF
--- a/programs/mpl-core/src/plugins/data_store.rs
+++ b/programs/mpl-core/src/plugins/data_store.rs
@@ -23,6 +23,22 @@ pub struct DataStore {
     pub data_len: usize,
 }
 
+impl PluginValidation for DataStore {
+    fn validate_add_external_plugin(
+        &self,
+        _ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        Ok(ValidationResult::Pass)
+    }
+
+    fn validate_transfer(
+        &self,
+        _ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        Ok(ValidationResult::Pass)
+    }
+}
+
 impl From<&DataStoreInitInfo> for DataStore {
     fn from(init_info: &DataStoreInitInfo) -> Self {
         Self {
@@ -44,15 +60,6 @@ pub struct DataStoreInitInfo {
     pub init_plugin_authority: Option<Authority>,
     /// Schema for the data used by the plugin.
     pub schema: Option<ExternalPluginSchema>,
-}
-
-impl PluginValidation for DataStoreInitInfo {
-    fn validate_add_external_plugin(
-        &self,
-        _ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        Ok(ValidationResult::Pass)
-    }
 }
 
 /// Data store update info.

--- a/programs/mpl-core/src/plugins/external_plugins.rs
+++ b/programs/mpl-core/src/plugins/external_plugins.rs
@@ -93,31 +93,63 @@ impl ExternalPlugin {
 
     /// Validate the add external plugin lifecycle event.
     pub(crate) fn validate_create(
-        init_info: &ExternalPluginInitInfo,
+        external_plugin: &ExternalPlugin,
         ctx: &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError> {
-        match init_info {
-            ExternalPluginInitInfo::LifecycleHook(init_info) => init_info.validate_create(ctx),
-            ExternalPluginInitInfo::Oracle(init_info) => init_info.validate_create(ctx),
-            ExternalPluginInitInfo::DataStore(init_info) => init_info.validate_create(ctx),
+        match external_plugin {
+            ExternalPlugin::LifecycleHook(lifecycle_hook) => lifecycle_hook.validate_create(ctx),
+            ExternalPlugin::Oracle(oracle) => oracle.validate_create(ctx),
+            ExternalPlugin::DataStore(data_store) => data_store.validate_create(ctx),
+        }
+    }
+
+    /// Route the validation of the update action to the appropriate plugin.
+    pub(crate) fn validate_update(
+        external_plugin: &ExternalPlugin,
+        ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        match external_plugin {
+            ExternalPlugin::LifecycleHook(lifecycle_hook) => lifecycle_hook.validate_update(ctx),
+            ExternalPlugin::Oracle(oracle) => oracle.validate_update(ctx),
+            ExternalPlugin::DataStore(data_store) => data_store.validate_update(ctx),
+        }
+    }
+
+    /// Route the validation of the burn action to the appropriate plugin.
+    pub(crate) fn validate_burn(
+        external_plugin: &ExternalPlugin,
+        ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        match external_plugin {
+            ExternalPlugin::LifecycleHook(lifecycle_hook) => lifecycle_hook.validate_burn(ctx),
+            ExternalPlugin::Oracle(oracle) => oracle.validate_burn(ctx),
+            ExternalPlugin::DataStore(data_store) => data_store.validate_burn(ctx),
+        }
+    }
+
+    /// Route the validation of the transfer action to the appropriate external plugin.
+    pub(crate) fn validate_transfer(
+        external_plugin: &ExternalPlugin,
+        ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        match external_plugin {
+            ExternalPlugin::LifecycleHook(lifecycle_hook) => lifecycle_hook.validate_transfer(ctx),
+            ExternalPlugin::Oracle(oracle) => oracle.validate_transfer(ctx),
+            ExternalPlugin::DataStore(data_store) => data_store.validate_transfer(ctx),
         }
     }
 
     /// Validate the add external plugin lifecycle event.
     pub(crate) fn validate_add_external_plugin(
-        init_info: &ExternalPluginInitInfo,
+        external_plugin: &ExternalPlugin,
         ctx: &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError> {
-        match init_info {
-            ExternalPluginInitInfo::LifecycleHook(init_info) => {
-                init_info.validate_add_external_plugin(ctx)
+        match external_plugin {
+            ExternalPlugin::LifecycleHook(lifecycle_hook) => {
+                lifecycle_hook.validate_add_external_plugin(ctx)
             }
-            ExternalPluginInitInfo::Oracle(init_info) => {
-                init_info.validate_add_external_plugin(ctx)
-            }
-            ExternalPluginInitInfo::DataStore(init_info) => {
-                init_info.validate_add_external_plugin(ctx)
-            }
+            ExternalPlugin::Oracle(oracle) => oracle.validate_add_external_plugin(ctx),
+            ExternalPlugin::DataStore(data_store) => data_store.validate_add_external_plugin(ctx),
         }
     }
 

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -8,7 +8,7 @@ use crate::{
     state::{Authority, Key},
 };
 
-use super::{ExternalPlugin, Plugin, PluginType, RegistryRecord};
+use super::{Plugin, PluginType, RegistryRecord};
 
 /// Lifecycle permissions
 /// Plugins use this field to indicate their permission to approve or deny
@@ -815,9 +815,6 @@ pub(crate) fn validate_plugin_checks<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-    external_plugin_validate_fp: Option<
-        fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
-    >,
 ) -> Result<ValidationResult, ProgramError> {
     let mut approved = false;
     let mut rejected = false;

--- a/programs/mpl-core/src/plugins/lifecycle_hook.rs
+++ b/programs/mpl-core/src/plugins/lifecycle_hook.rs
@@ -30,6 +30,22 @@ pub struct LifecycleHook {
     pub data_len: usize, // 8
 }
 
+impl PluginValidation for LifecycleHook {
+    fn validate_add_external_plugin(
+        &self,
+        _ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        Ok(ValidationResult::Pass)
+    }
+
+    fn validate_transfer(
+        &self,
+        _ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        Ok(ValidationResult::Pass)
+    }
+}
+
 impl From<&LifecycleHookInitInfo> for LifecycleHook {
     fn from(init_info: &LifecycleHookInitInfo) -> Self {
         Self {
@@ -60,15 +76,6 @@ pub struct LifecycleHookInitInfo {
     pub data_authority: Option<Authority>,
     /// Schema for the data used by the plugin.
     pub schema: Option<ExternalPluginSchema>,
-}
-
-impl PluginValidation for LifecycleHookInitInfo {
-    fn validate_add_external_plugin(
-        &self,
-        _ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        Ok(ValidationResult::Pass)
-    }
 }
 
 /// Lifecycle hook update info.

--- a/programs/mpl-core/src/plugins/oracle.rs
+++ b/programs/mpl-core/src/plugins/oracle.rs
@@ -20,6 +20,22 @@ pub struct Oracle {
     pub results_offset: ValidationResultsOffset,
 }
 
+impl PluginValidation for Oracle {
+    fn validate_add_external_plugin(
+        &self,
+        _ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        Ok(ValidationResult::Pass)
+    }
+
+    fn validate_transfer(
+        &self,
+        _ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        Ok(ValidationResult::Pass)
+    }
+}
+
 impl From<&OracleInitInfo> for Oracle {
     fn from(init_info: &OracleInitInfo) -> Self {
         Self {
@@ -48,15 +64,6 @@ pub struct OracleInitInfo {
     /// Optional offset for validation results struct used in Oracle account.  Default
     /// is `ValidationResultsOffset::NoOffset`.
     pub results_offset: Option<ValidationResultsOffset>,
-}
-
-impl PluginValidation for OracleInitInfo {
-    fn validate_add_external_plugin(
-        &self,
-        _ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        Ok(ValidationResult::Pass)
-    }
 }
 
 /// Oracle update info.

--- a/programs/mpl-core/src/processor/add_external_plugin.rs
+++ b/programs/mpl-core/src/processor/add_external_plugin.rs
@@ -55,8 +55,10 @@ pub(crate) fn add_external_plugin<'a>(
         target_plugin: None,
     };
 
-    if ExternalPlugin::validate_add_external_plugin(&args.init_info, &validation_ctx)?
-        == ValidationResult::Rejected
+    if ExternalPlugin::validate_add_external_plugin(
+        &ExternalPlugin::from(&args.init_info),
+        &validation_ctx,
+    )? == ValidationResult::Rejected
     {
         return Err(MplCoreError::InvalidAuthority.into());
     }
@@ -75,6 +77,7 @@ pub(crate) fn add_external_plugin<'a>(
         AssetV1::validate_add_external_plugin,
         CollectionV1::validate_add_external_plugin,
         Plugin::validate_add_external_plugin,
+        Some(ExternalPlugin::validate_add_external_plugin),
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -123,8 +126,10 @@ pub(crate) fn add_collection_external_plugin<'a>(
         target_plugin: None,
     };
 
-    if ExternalPlugin::validate_add_external_plugin(&args.init_info, &validation_ctx)?
-        == ValidationResult::Rejected
+    if ExternalPlugin::validate_add_external_plugin(
+        &ExternalPlugin::from(&args.init_info),
+        &validation_ctx,
+    )? == ValidationResult::Rejected
     {
         return Err(MplCoreError::InvalidAuthority.into());
     }
@@ -139,6 +144,7 @@ pub(crate) fn add_collection_external_plugin<'a>(
         PluginType::check_add_external_plugin,
         CollectionV1::validate_add_external_plugin,
         Plugin::validate_add_external_plugin,
+        Some(ExternalPlugin::validate_add_external_plugin),
     )?;
 
     process_add_external_plugin::<CollectionV1>(

--- a/programs/mpl-core/src/processor/add_plugin.rs
+++ b/programs/mpl-core/src/processor/add_plugin.rs
@@ -73,6 +73,7 @@ pub(crate) fn add_plugin<'a>(
         AssetV1::validate_add_plugin,
         CollectionV1::validate_add_plugin,
         Plugin::validate_add_plugin,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -141,6 +142,7 @@ pub(crate) fn add_collection_plugin<'a>(
         PluginType::check_add_plugin,
         CollectionV1::validate_add_plugin,
         Plugin::validate_add_plugin,
+        None,
     )?;
 
     process_add_plugin::<CollectionV1>(

--- a/programs/mpl-core/src/processor/approve_plugin_authority.rs
+++ b/programs/mpl-core/src/processor/approve_plugin_authority.rs
@@ -63,6 +63,7 @@ pub(crate) fn approve_plugin_authority<'a>(
         AssetV1::validate_approve_plugin_authority,
         CollectionV1::validate_approve_plugin_authority,
         Plugin::validate_approve_plugin_authority,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -117,6 +118,7 @@ pub(crate) fn approve_collection_plugin_authority<'a>(
         PluginType::check_approve_plugin_authority,
         CollectionV1::validate_approve_plugin_authority,
         Plugin::validate_approve_plugin_authority,
+        None,
     )?;
 
     process_approve_plugin_authority::<CollectionV1>(

--- a/programs/mpl-core/src/processor/burn.rs
+++ b/programs/mpl-core/src/processor/burn.rs
@@ -5,7 +5,7 @@ use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg};
 use crate::{
     error::MplCoreError,
     instruction::accounts::{BurnCollectionV1Accounts, BurnV1Accounts},
-    plugins::{Plugin, PluginType},
+    plugins::{ExternalPlugin, Plugin, PluginType},
     state::{AssetV1, CollectionV1, CompressionProof, Key, SolanaAccount, Wrappable},
     utils::{
         close_program_account, load_key, rebuild_account_state_from_proof_data, resolve_authority,
@@ -96,6 +96,7 @@ pub(crate) fn burn<'a>(accounts: &'a [AccountInfo<'a>], args: BurnV1Args) -> Pro
         AssetV1::validate_burn,
         CollectionV1::validate_burn,
         Plugin::validate_burn,
+        Some(ExternalPlugin::validate_burn),
     )?;
 
     process_burn(ctx.accounts.asset, authority)?;
@@ -138,6 +139,7 @@ pub(crate) fn burn_collection<'a>(
         PluginType::check_burn,
         CollectionV1::validate_burn,
         Plugin::validate_burn,
+        Some(ExternalPlugin::validate_burn),
     )?;
 
     process_burn(ctx.accounts.collection, authority)

--- a/programs/mpl-core/src/processor/compress.rs
+++ b/programs/mpl-core/src/processor/compress.rs
@@ -56,6 +56,7 @@ pub(crate) fn compress<'a>(
                 AssetV1::validate_compress,
                 CollectionV1::validate_compress,
                 Plugin::validate_compress,
+                None,
             )?;
 
             // Compress the asset and plugin registry into account space.

--- a/programs/mpl-core/src/processor/create.rs
+++ b/programs/mpl-core/src/processor/create.rs
@@ -209,8 +209,10 @@ pub(crate) fn process_create<'a>(
                             new_owner: None,
                             target_plugin: None,
                         };
-                        if ExternalPlugin::validate_create(plugin_init_info, &validation_ctx)?
-                            == ValidationResult::Rejected
+                        if ExternalPlugin::validate_create(
+                            &ExternalPlugin::from(plugin_init_info),
+                            &validation_ctx,
+                        )? == ValidationResult::Rejected
                         {
                             approved = false;
                         }

--- a/programs/mpl-core/src/processor/create_collection.rs
+++ b/programs/mpl-core/src/processor/create_collection.rs
@@ -174,8 +174,10 @@ pub(crate) fn process_create_collection<'a>(
                         new_owner: None,
                         target_plugin: None,
                     };
-                    if ExternalPlugin::validate_create(plugin_init_info, &validation_ctx)?
-                        == ValidationResult::Rejected
+                    if ExternalPlugin::validate_create(
+                        &ExternalPlugin::from(plugin_init_info),
+                        &validation_ctx,
+                    )? == ValidationResult::Rejected
                     {
                         approved = false;
                     };

--- a/programs/mpl-core/src/processor/decompress.rs
+++ b/programs/mpl-core/src/processor/decompress.rs
@@ -72,6 +72,7 @@ pub(crate) fn decompress<'a>(
                 AssetV1::validate_decompress,
                 CollectionV1::validate_decompress,
                 Plugin::validate_decompress,
+                None,
             )?;
 
             // TODO Enable compression.

--- a/programs/mpl-core/src/processor/remove_plugin.rs
+++ b/programs/mpl-core/src/processor/remove_plugin.rs
@@ -69,6 +69,7 @@ pub(crate) fn remove_plugin<'a>(
         AssetV1::validate_remove_plugin,
         CollectionV1::validate_remove_plugin,
         Plugin::validate_remove_plugin,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -133,6 +134,7 @@ pub(crate) fn remove_collection_plugin<'a>(
         PluginType::check_remove_plugin,
         CollectionV1::validate_remove_plugin,
         Plugin::validate_remove_plugin,
+        None,
     )?;
 
     process_remove_plugin(

--- a/programs/mpl-core/src/processor/revoke_plugin_authority.rs
+++ b/programs/mpl-core/src/processor/revoke_plugin_authority.rs
@@ -70,6 +70,7 @@ pub(crate) fn revoke_plugin_authority<'a>(
         AssetV1::validate_revoke_plugin_authority,
         CollectionV1::validate_revoke_plugin_authority,
         Plugin::validate_revoke_plugin_authority,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -138,6 +139,7 @@ pub(crate) fn revoke_collection_plugin_authority<'a>(
         PluginType::check_revoke_plugin_authority,
         CollectionV1::validate_revoke_plugin_authority,
         Plugin::validate_revoke_plugin_authority,
+        None,
     )?;
 
     let resolved_authorities =

--- a/programs/mpl-core/src/processor/transfer.rs
+++ b/programs/mpl-core/src/processor/transfer.rs
@@ -5,7 +5,7 @@ use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg};
 use crate::{
     error::MplCoreError,
     instruction::accounts::TransferV1Accounts,
-    plugins::{Plugin, PluginType},
+    plugins::{ExternalPlugin, Plugin, PluginType},
     state::{AssetV1, Authority, CollectionV1, CompressionProof, Key, SolanaAccount, Wrappable},
     utils::{
         compress_into_account_space, load_key, rebuild_account_state_from_proof_data,
@@ -89,6 +89,7 @@ pub(crate) fn transfer<'a>(accounts: &'a [AccountInfo<'a>], args: TransferV1Args
         AssetV1::validate_transfer,
         CollectionV1::validate_transfer,
         Plugin::validate_transfer,
+        Some(ExternalPlugin::validate_transfer),
     )?;
 
     // Reset every owner-managed plugin in the registry.

--- a/programs/mpl-core/src/processor/update.rs
+++ b/programs/mpl-core/src/processor/update.rs
@@ -7,7 +7,9 @@ use solana_program::{
 use crate::{
     error::MplCoreError,
     instruction::accounts::{UpdateCollectionV1Accounts, UpdateV1Accounts},
-    plugins::{Plugin, PluginHeaderV1, PluginRegistryV1, PluginType, RegistryRecord},
+    plugins::{
+        ExternalPlugin, Plugin, PluginHeaderV1, PluginRegistryV1, PluginType, RegistryRecord,
+    },
     state::{AssetV1, CollectionV1, DataBlob, Key, SolanaAccount, UpdateAuthority},
     utils::{
         load_key, resize_or_reallocate_account, resolve_authority, validate_asset_permissions,
@@ -59,6 +61,7 @@ pub(crate) fn update<'a>(accounts: &'a [AccountInfo<'a>], args: UpdateV1Args) ->
         AssetV1::validate_update,
         CollectionV1::validate_update,
         Plugin::validate_update,
+        Some(ExternalPlugin::validate_update),
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -142,6 +145,7 @@ pub(crate) fn update_collection<'a>(
         PluginType::check_update,
         CollectionV1::validate_update,
         Plugin::validate_update,
+        Some(ExternalPlugin::validate_update),
     )?;
 
     let collection_size = collection.get_size() as isize;

--- a/programs/mpl-core/src/processor/update_plugin.rs
+++ b/programs/mpl-core/src/processor/update_plugin.rs
@@ -60,6 +60,7 @@ pub(crate) fn update_plugin<'a>(
         AssetV1::validate_update_plugin,
         CollectionV1::validate_update_plugin,
         Plugin::validate_update_plugin,
+        None,
     )?;
 
     let mut plugin_registry = plugin_registry.ok_or(MplCoreError::PluginsNotInitialized)?;
@@ -188,6 +189,7 @@ pub(crate) fn update_collection_plugin<'a>(
         PluginType::check_update_plugin,
         CollectionV1::validate_update_plugin,
         Plugin::validate_update_plugin,
+        None,
     )?;
 
     // let (collection, plugin_header, plugin_registry) =

--- a/programs/mpl-core/src/utils.rs
+++ b/programs/mpl-core/src/utils.rs
@@ -220,7 +220,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-    external_plugin_validate_fp: Option<
+    _external_plugin_validate_fp: Option<
         fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
     >,
 ) -> Result<(AssetV1, Option<PluginHeaderV1>, Option<PluginRegistryV1>), ProgramError> {
@@ -310,7 +310,6 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
-        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -330,7 +329,6 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
-        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -368,7 +366,7 @@ pub(crate) fn validate_collection_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-    external_plugin_validate_fp: Option<
+    _external_plugin_validate_fp: Option<
         fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
     >,
 ) -> Result<
@@ -431,7 +429,6 @@ pub(crate) fn validate_collection_permissions<'a>(
         Some(collection),
         &resolved_authorities,
         plugin_validate_fp,
-        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,

--- a/programs/mpl-core/src/utils.rs
+++ b/programs/mpl-core/src/utils.rs
@@ -13,8 +13,8 @@ use crate::{
     error::MplCoreError,
     plugins::{
         create_meta_idempotent, initialize_plugin, validate_plugin_checks, CheckResult,
-        ExternalPluginInitInfo, Plugin, PluginHeaderV1, PluginRegistryV1, PluginType,
-        PluginValidationContext, RegistryRecord, ValidationResult,
+        ExternalPlugin, ExternalPluginInitInfo, Plugin, PluginHeaderV1, PluginRegistryV1,
+        PluginType, PluginValidationContext, RegistryRecord, ValidationResult,
     },
     state::{
         AssetV1, Authority, CollectionV1, Compressible, CompressionProof, CoreAsset, DataBlob,
@@ -220,6 +220,9 @@ pub(crate) fn validate_asset_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
+    external_plugin_validate_fp: Option<
+        fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
+    >,
 ) -> Result<(AssetV1, Option<PluginHeaderV1>, Option<PluginRegistryV1>), ProgramError> {
     let (deserialized_asset, plugin_header, plugin_registry) = fetch_core_data::<AssetV1>(asset)?;
     let resolved_authorities =
@@ -307,6 +310,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
+        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -326,6 +330,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
+        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -363,6 +368,9 @@ pub(crate) fn validate_collection_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
+    external_plugin_validate_fp: Option<
+        fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
+    >,
 ) -> Result<
     (
         CollectionV1,
@@ -423,6 +431,7 @@ pub(crate) fn validate_collection_permissions<'a>(
         Some(collection),
         &resolved_authorities,
         plugin_validate_fp,
+        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,


### PR DESCRIPTION
This PR sets up additional needed validation functions for external plugins.  It is mostly boilerplate and is meant to be followed by https://github.com/metaplex-foundation/mpl-core/pull/86.

### Notes
* Modify `ExternalPlugin::validate_create` to take an `&ExternalPlugin` rather than an `&ExternalPluginInitInfo`.
* Add `ExternalPlugin` level validation functions to use for `transfer`, `burn`, `update`.
* Move `PluginValidation` traits from external plugin `InitInfo` structs to external plugin structs.


