### PR TITLE
Call external plugin validations

### DIFF
--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -8,7 +8,9 @@ use crate::{
     state::{Authority, Key},
 };
 
-use super::{Plugin, PluginType, RegistryRecord};
+use super::{
+    ExternalPlugin, ExternalPluginKey, ExternalRegistryRecord, Plugin, PluginType, RegistryRecord,
+};
 
 /// Lifecycle permissions
 /// Plugins use this field to indicate their permission to approve or deny
@@ -840,6 +842,71 @@ pub(crate) fn validate_plugin_checks<'a>(
             };
 
             let result = plugin_validate_fp(&Plugin::load(account, registry_record.offset)?, &ctx)?;
+            match result {
+                ValidationResult::Rejected => rejected = true,
+                ValidationResult::Approved => approved = true,
+                ValidationResult::Pass => continue,
+                ValidationResult::ForceApproved => return Ok(ValidationResult::ForceApproved),
+            }
+        }
+    }
+
+    if rejected {
+        Ok(ValidationResult::Rejected)
+    } else if approved {
+        Ok(ValidationResult::Approved)
+    } else {
+        Ok(ValidationResult::Pass)
+    }
+}
+
+/// This function iterates through all external plugin checks passed in and performs the validation
+/// by deserializing and calling validate on the plugin.
+/// The STRONGEST result is returned.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub(crate) fn validate_external_plugin_checks<'a>(
+    key: Key,
+    external_checks: &BTreeMap<
+        ExternalPluginKey,
+        (Key, ExternalCheckResultBits, ExternalRegistryRecord),
+    >,
+    authority: &'a AccountInfo<'a>,
+    new_owner: Option<&'a AccountInfo<'a>>,
+    new_plugin: Option<&Plugin>,
+    asset: Option<&AccountInfo<'a>>,
+    collection: Option<&AccountInfo<'a>>,
+    resolved_authorities: &[Authority],
+    external_plugin_validate_fp: fn(
+        &ExternalPlugin,
+        &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError>,
+) -> Result<ValidationResult, ProgramError> {
+    let mut approved = false;
+    let mut rejected = false;
+    for (check_key, check_result, external_registry_record) in external_checks.values() {
+        if *check_key == key
+            && (check_result.can_listen()
+                || check_result.can_approve()
+                || check_result.can_reject())
+        {
+            let account = match key {
+                Key::CollectionV1 => collection.ok_or(MplCoreError::InvalidCollection)?,
+                Key::AssetV1 => asset.ok_or(MplCoreError::InvalidAsset)?,
+                _ => unreachable!(),
+            };
+
+            let ctx = PluginValidationContext {
+                self_authority: &external_registry_record.authority,
+                authority_info: authority,
+                resolved_authorities: Some(resolved_authorities),
+                new_owner,
+                target_plugin: new_plugin,
+            };
+
+            let result = external_plugin_validate_fp(
+                &ExternalPlugin::load(account, external_registry_record.offset)?,
+                &ctx,
+            )?;
             match result {
                 ValidationResult::Rejected => rejected = true,
                 ValidationResult::Approved => approved = true,

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -910,8 +910,7 @@ pub(crate) fn validate_external_plugin_checks<'a>(
             match result {
                 ValidationResult::Rejected => rejected = true,
                 ValidationResult::Approved => approved = true,
-                ValidationResult::Pass => continue,
-                ValidationResult::ForceApproved => return Ok(ValidationResult::ForceApproved),
+                ValidationResult::Pass | ValidationResult::ForceApproved => continue,
             }
         }
     }

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -8,7 +8,7 @@ use crate::{
     state::{Authority, Key},
 };
 
-use super::{ExternalPlugin, Plugin, PluginType, RegistryRecord};
+use super::{Plugin, PluginType, RegistryRecord};
 
 /// Lifecycle permissions
 /// Plugins use this field to indicate their permission to approve or deny

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -8,7 +8,7 @@ use crate::{
     state::{Authority, Key},
 };
 
-use super::{Plugin, PluginType, RegistryRecord};
+use super::{ExternalPlugin, Plugin, PluginType, RegistryRecord};
 
 /// Lifecycle permissions
 /// Plugins use this field to indicate their permission to approve or deny

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -882,7 +882,6 @@ pub(crate) fn validate_external_plugin_checks<'a>(
     ) -> Result<ValidationResult, ProgramError>,
 ) -> Result<ValidationResult, ProgramError> {
     let mut approved = false;
-    let mut rejected = false;
     for (check_key, check_result, external_registry_record) in external_checks.values() {
         if *check_key == key
             && (check_result.can_listen()
@@ -908,16 +907,16 @@ pub(crate) fn validate_external_plugin_checks<'a>(
                 &ctx,
             )?;
             match result {
-                ValidationResult::Rejected => rejected = true,
+                ValidationResult::Rejected => return Ok(ValidationResult::Rejected),
                 ValidationResult::Approved => approved = true,
-                ValidationResult::Pass | ValidationResult::ForceApproved => continue,
+                ValidationResult::Pass => continue,
+                // Force approved will not be possible from external plugins.
+                ValidationResult::ForceApproved => unreachable!(),
             }
         }
     }
 
-    if rejected {
-        Ok(ValidationResult::Rejected)
-    } else if approved {
+    if approved {
         Ok(ValidationResult::Approved)
     } else {
         Ok(ValidationResult::Pass)

--- a/programs/mpl-core/src/processor/add_external_plugin.rs
+++ b/programs/mpl-core/src/processor/add_external_plugin.rs
@@ -79,7 +79,8 @@ pub(crate) fn add_external_plugin<'a>(
         AssetV1::validate_add_external_plugin,
         CollectionV1::validate_add_external_plugin,
         Plugin::validate_add_external_plugin,
-        Some(ExternalPlugin::validate_add_external_plugin),
+        None,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -148,7 +149,8 @@ pub(crate) fn add_collection_external_plugin<'a>(
         PluginType::check_add_external_plugin,
         CollectionV1::validate_add_external_plugin,
         Plugin::validate_add_external_plugin,
-        Some(ExternalPlugin::validate_add_external_plugin),
+        None,
+        None,
     )?;
 
     process_add_external_plugin::<CollectionV1>(

--- a/programs/mpl-core/src/processor/add_plugin.rs
+++ b/programs/mpl-core/src/processor/add_plugin.rs
@@ -74,6 +74,7 @@ pub(crate) fn add_plugin<'a>(
         CollectionV1::validate_add_plugin,
         Plugin::validate_add_plugin,
         None,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -142,6 +143,7 @@ pub(crate) fn add_collection_plugin<'a>(
         PluginType::check_add_plugin,
         CollectionV1::validate_add_plugin,
         Plugin::validate_add_plugin,
+        None,
         None,
     )?;
 

--- a/programs/mpl-core/src/processor/approve_plugin_authority.rs
+++ b/programs/mpl-core/src/processor/approve_plugin_authority.rs
@@ -64,6 +64,7 @@ pub(crate) fn approve_plugin_authority<'a>(
         CollectionV1::validate_approve_plugin_authority,
         Plugin::validate_approve_plugin_authority,
         None,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -118,6 +119,7 @@ pub(crate) fn approve_collection_plugin_authority<'a>(
         PluginType::check_approve_plugin_authority,
         CollectionV1::validate_approve_plugin_authority,
         Plugin::validate_approve_plugin_authority,
+        None,
         None,
     )?;
 

--- a/programs/mpl-core/src/processor/burn.rs
+++ b/programs/mpl-core/src/processor/burn.rs
@@ -5,7 +5,7 @@ use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg};
 use crate::{
     error::MplCoreError,
     instruction::accounts::{BurnCollectionV1Accounts, BurnV1Accounts},
-    plugins::{ExternalPlugin, Plugin, PluginType},
+    plugins::{ExternalPlugin, HookableLifecycleEvent, Plugin, PluginType},
     state::{AssetV1, CollectionV1, CompressionProof, Key, SolanaAccount, Wrappable},
     utils::{
         close_program_account, load_key, rebuild_account_state_from_proof_data, resolve_authority,
@@ -97,6 +97,7 @@ pub(crate) fn burn<'a>(accounts: &'a [AccountInfo<'a>], args: BurnV1Args) -> Pro
         CollectionV1::validate_burn,
         Plugin::validate_burn,
         Some(ExternalPlugin::validate_burn),
+        Some(HookableLifecycleEvent::Burn),
     )?;
 
     process_burn(ctx.accounts.asset, authority)?;
@@ -140,6 +141,7 @@ pub(crate) fn burn_collection<'a>(
         CollectionV1::validate_burn,
         Plugin::validate_burn,
         Some(ExternalPlugin::validate_burn),
+        Some(HookableLifecycleEvent::Burn),
     )?;
 
     process_burn(ctx.accounts.collection, authority)

--- a/programs/mpl-core/src/processor/compress.rs
+++ b/programs/mpl-core/src/processor/compress.rs
@@ -57,6 +57,7 @@ pub(crate) fn compress<'a>(
                 CollectionV1::validate_compress,
                 Plugin::validate_compress,
                 None,
+                None,
             )?;
 
             // Compress the asset and plugin registry into account space.

--- a/programs/mpl-core/src/processor/decompress.rs
+++ b/programs/mpl-core/src/processor/decompress.rs
@@ -73,6 +73,7 @@ pub(crate) fn decompress<'a>(
                 CollectionV1::validate_decompress,
                 Plugin::validate_decompress,
                 None,
+                None,
             )?;
 
             // TODO Enable compression.

--- a/programs/mpl-core/src/processor/remove_external_plugin.rs
+++ b/programs/mpl-core/src/processor/remove_external_plugin.rs
@@ -74,6 +74,8 @@ pub(crate) fn remove_external_plugin<'a>(
         AssetV1::validate_remove_external_plugin,
         CollectionV1::validate_remove_external_plugin,
         Plugin::validate_remove_external_plugin,
+        None,
+        None,
     )?;
 
     process_remove_external_plugin(
@@ -136,6 +138,8 @@ pub(crate) fn remove_collection_external_plugin<'a>(
         PluginType::check_remove_external_plugin,
         CollectionV1::validate_remove_external_plugin,
         Plugin::validate_remove_external_plugin,
+        None,
+        None,
     )?;
 
     process_remove_external_plugin(

--- a/programs/mpl-core/src/processor/remove_plugin.rs
+++ b/programs/mpl-core/src/processor/remove_plugin.rs
@@ -70,6 +70,7 @@ pub(crate) fn remove_plugin<'a>(
         CollectionV1::validate_remove_plugin,
         Plugin::validate_remove_plugin,
         None,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -134,6 +135,7 @@ pub(crate) fn remove_collection_plugin<'a>(
         PluginType::check_remove_plugin,
         CollectionV1::validate_remove_plugin,
         Plugin::validate_remove_plugin,
+        None,
         None,
     )?;
 

--- a/programs/mpl-core/src/processor/revoke_plugin_authority.rs
+++ b/programs/mpl-core/src/processor/revoke_plugin_authority.rs
@@ -71,6 +71,7 @@ pub(crate) fn revoke_plugin_authority<'a>(
         CollectionV1::validate_revoke_plugin_authority,
         Plugin::validate_revoke_plugin_authority,
         None,
+        None,
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -139,6 +140,7 @@ pub(crate) fn revoke_collection_plugin_authority<'a>(
         PluginType::check_revoke_plugin_authority,
         CollectionV1::validate_revoke_plugin_authority,
         Plugin::validate_revoke_plugin_authority,
+        None,
         None,
     )?;
 

--- a/programs/mpl-core/src/processor/transfer.rs
+++ b/programs/mpl-core/src/processor/transfer.rs
@@ -5,7 +5,7 @@ use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg};
 use crate::{
     error::MplCoreError,
     instruction::accounts::TransferV1Accounts,
-    plugins::{ExternalPlugin, Plugin, PluginType},
+    plugins::{ExternalPlugin, HookableLifecycleEvent, Plugin, PluginType},
     state::{AssetV1, Authority, CollectionV1, CompressionProof, Key, SolanaAccount, Wrappable},
     utils::{
         compress_into_account_space, load_key, rebuild_account_state_from_proof_data,
@@ -90,6 +90,7 @@ pub(crate) fn transfer<'a>(accounts: &'a [AccountInfo<'a>], args: TransferV1Args
         CollectionV1::validate_transfer,
         Plugin::validate_transfer,
         Some(ExternalPlugin::validate_transfer),
+        Some(HookableLifecycleEvent::Transfer),
     )?;
 
     // Reset every owner-managed plugin in the registry.

--- a/programs/mpl-core/src/processor/update.rs
+++ b/programs/mpl-core/src/processor/update.rs
@@ -8,7 +8,8 @@ use crate::{
     error::MplCoreError,
     instruction::accounts::{UpdateCollectionV1Accounts, UpdateV1Accounts},
     plugins::{
-        ExternalPlugin, Plugin, PluginHeaderV1, PluginRegistryV1, PluginType, RegistryRecord,
+        ExternalPlugin, HookableLifecycleEvent, Plugin, PluginHeaderV1, PluginRegistryV1,
+        PluginType, RegistryRecord,
     },
     state::{AssetV1, CollectionV1, DataBlob, Key, SolanaAccount, UpdateAuthority},
     utils::{
@@ -62,6 +63,7 @@ pub(crate) fn update<'a>(accounts: &'a [AccountInfo<'a>], args: UpdateV1Args) ->
         CollectionV1::validate_update,
         Plugin::validate_update,
         Some(ExternalPlugin::validate_update),
+        Some(HookableLifecycleEvent::Update),
     )?;
 
     // Increment sequence number and save only if it is `Some(_)`.
@@ -146,6 +148,7 @@ pub(crate) fn update_collection<'a>(
         CollectionV1::validate_update,
         Plugin::validate_update,
         Some(ExternalPlugin::validate_update),
+        Some(HookableLifecycleEvent::Update),
     )?;
 
     let collection_size = collection.get_size() as isize;

--- a/programs/mpl-core/src/processor/update_plugin.rs
+++ b/programs/mpl-core/src/processor/update_plugin.rs
@@ -61,6 +61,7 @@ pub(crate) fn update_plugin<'a>(
         CollectionV1::validate_update_plugin,
         Plugin::validate_update_plugin,
         None,
+        None,
     )?;
 
     let mut plugin_registry = plugin_registry.ok_or(MplCoreError::PluginsNotInitialized)?;
@@ -189,6 +190,7 @@ pub(crate) fn update_collection_plugin<'a>(
         PluginType::check_update_plugin,
         CollectionV1::validate_update_plugin,
         Plugin::validate_update_plugin,
+        None,
         None,
     )?;
 

--- a/programs/mpl-core/src/utils.rs
+++ b/programs/mpl-core/src/utils.rs
@@ -537,7 +537,9 @@ pub(crate) fn validate_collection_permissions<'a>(
         )? {
             ValidationResult::Approved => approved = true,
             ValidationResult::Rejected => rejected = true,
-            ValidationResult::Pass | ValidationResult::ForceApproved => (),
+            ValidationResult::Pass => (),
+            // Force approved will not be possible from external plugins.
+            ValidationResult::ForceApproved => unreachable!(),
         };
     }
 

--- a/programs/mpl-core/src/utils.rs
+++ b/programs/mpl-core/src/utils.rs
@@ -220,7 +220,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-    external_plugin_validate_fp: Option<
+    _external_plugin_validate_fp: Option<
         fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
     >,
 ) -> Result<(AssetV1, Option<PluginHeaderV1>, Option<PluginRegistryV1>), ProgramError> {
@@ -310,7 +310,6 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
-        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -330,7 +329,6 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
-        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -368,7 +366,6 @@ pub(crate) fn validate_collection_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-
     external_plugin_validate_fp: Option<
         fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
     >,
@@ -432,7 +429,6 @@ pub(crate) fn validate_collection_permissions<'a>(
         Some(collection),
         &resolved_authorities,
         plugin_validate_fp,
-        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,

--- a/programs/mpl-core/src/utils.rs
+++ b/programs/mpl-core/src/utils.rs
@@ -380,7 +380,9 @@ pub(crate) fn validate_asset_permissions<'a>(
         )? {
             ValidationResult::Approved => approved = true,
             ValidationResult::Rejected => rejected = true,
-            ValidationResult::Pass | ValidationResult::ForceApproved => (),
+            ValidationResult::Pass => (),
+            // Force approved will not be possible from external plugins.
+            ValidationResult::ForceApproved => unreachable!(),
         };
 
         match validate_external_plugin_checks(
@@ -396,7 +398,9 @@ pub(crate) fn validate_asset_permissions<'a>(
         )? {
             ValidationResult::Approved => approved = true,
             ValidationResult::Rejected => rejected = true,
-            ValidationResult::Pass | ValidationResult::ForceApproved => (),
+            ValidationResult::Pass => (),
+            // Force approved will not be possible from external plugins.
+            ValidationResult::ForceApproved => unreachable!(),
         };
     }
 

--- a/programs/mpl-core/src/utils.rs
+++ b/programs/mpl-core/src/utils.rs
@@ -220,7 +220,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-    _external_plugin_validate_fp: Option<
+    external_plugin_validate_fp: Option<
         fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
     >,
 ) -> Result<(AssetV1, Option<PluginHeaderV1>, Option<PluginRegistryV1>), ProgramError> {
@@ -310,6 +310,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
+        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -329,6 +330,7 @@ pub(crate) fn validate_asset_permissions<'a>(
         collection,
         &resolved_authorities,
         plugin_validate_fp,
+        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,
@@ -366,7 +368,8 @@ pub(crate) fn validate_collection_permissions<'a>(
         &Plugin,
         &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError>,
-    _external_plugin_validate_fp: Option<
+
+    external_plugin_validate_fp: Option<
         fn(&ExternalPlugin, &PluginValidationContext) -> Result<ValidationResult, ProgramError>,
     >,
 ) -> Result<
@@ -429,6 +432,7 @@ pub(crate) fn validate_collection_permissions<'a>(
         Some(collection),
         &resolved_authorities,
         plugin_validate_fp,
+        external_plugin_validate_fp,
     )? {
         ValidationResult::Approved => approved = true,
         ValidationResult::Rejected => rejected = true,


### PR DESCRIPTION
### Notes
* This PR adds the code to call external plugin validations in both `validate_asset_permissions` and `validate_collection_permissions`.
* It is built on top of https://github.com/metaplex-foundation/mpl-core/pull/85