### PR TITLE
Add Address seed and remove Program seed

### DIFF
--- a/clients/js/src/generated/types/baseExternalPluginInitInfo.ts
+++ b/clients/js/src/generated/types/baseExternalPluginInitInfo.ts
@@ -88,14 +88,14 @@ export function baseExternalPluginInitInfo(
   >['fields']
 ): GetDataEnumKind<BaseExternalPluginInitInfoArgs, 'DataStore'>;
 export function baseExternalPluginInitInfo<
-  K extends BaseExternalPluginInitInfoArgs['__kind']
+  K extends BaseExternalPluginInitInfoArgs['__kind'],
 >(kind: K, data?: any): Extract<BaseExternalPluginInitInfoArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseExternalPluginInitInfo<
-  K extends BaseExternalPluginInitInfo['__kind']
+  K extends BaseExternalPluginInitInfo['__kind'],
 >(
   kind: K,
   value: BaseExternalPluginInitInfo

--- a/clients/js/src/generated/types/baseExternalPluginInitInfo.ts
+++ b/clients/js/src/generated/types/baseExternalPluginInitInfo.ts
@@ -88,14 +88,14 @@ export function baseExternalPluginInitInfo(
   >['fields']
 ): GetDataEnumKind<BaseExternalPluginInitInfoArgs, 'DataStore'>;
 export function baseExternalPluginInitInfo<
-  K extends BaseExternalPluginInitInfoArgs['__kind'],
+  K extends BaseExternalPluginInitInfoArgs['__kind']
 >(kind: K, data?: any): Extract<BaseExternalPluginInitInfoArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseExternalPluginInitInfo<
-  K extends BaseExternalPluginInitInfo['__kind'],
+  K extends BaseExternalPluginInitInfo['__kind']
 >(
   kind: K,
   value: BaseExternalPluginInitInfo

--- a/clients/js/src/generated/types/baseExternalPluginKey.ts
+++ b/clients/js/src/generated/types/baseExternalPluginKey.ts
@@ -78,14 +78,14 @@ export function baseExternalPluginKey(
   data: GetDataEnumKindContent<BaseExternalPluginKeyArgs, 'DataStore'>['fields']
 ): GetDataEnumKind<BaseExternalPluginKeyArgs, 'DataStore'>;
 export function baseExternalPluginKey<
-  K extends BaseExternalPluginKeyArgs['__kind'],
+  K extends BaseExternalPluginKeyArgs['__kind']
 >(kind: K, data?: any): Extract<BaseExternalPluginKeyArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseExternalPluginKey<
-  K extends BaseExternalPluginKey['__kind'],
+  K extends BaseExternalPluginKey['__kind']
 >(
   kind: K,
   value: BaseExternalPluginKey

--- a/clients/js/src/generated/types/baseExternalPluginKey.ts
+++ b/clients/js/src/generated/types/baseExternalPluginKey.ts
@@ -78,14 +78,14 @@ export function baseExternalPluginKey(
   data: GetDataEnumKindContent<BaseExternalPluginKeyArgs, 'DataStore'>['fields']
 ): GetDataEnumKind<BaseExternalPluginKeyArgs, 'DataStore'>;
 export function baseExternalPluginKey<
-  K extends BaseExternalPluginKeyArgs['__kind']
+  K extends BaseExternalPluginKeyArgs['__kind'],
 >(kind: K, data?: any): Extract<BaseExternalPluginKeyArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseExternalPluginKey<
-  K extends BaseExternalPluginKey['__kind']
+  K extends BaseExternalPluginKey['__kind'],
 >(
   kind: K,
   value: BaseExternalPluginKey

--- a/clients/js/src/generated/types/baseExternalPluginUpdateInfo.ts
+++ b/clients/js/src/generated/types/baseExternalPluginUpdateInfo.ts
@@ -91,7 +91,7 @@ export function baseExternalPluginUpdateInfo(
   >['fields']
 ): GetDataEnumKind<BaseExternalPluginUpdateInfoArgs, 'DataStore'>;
 export function baseExternalPluginUpdateInfo<
-  K extends BaseExternalPluginUpdateInfoArgs['__kind']
+  K extends BaseExternalPluginUpdateInfoArgs['__kind'],
 >(
   kind: K,
   data?: any
@@ -101,7 +101,7 @@ export function baseExternalPluginUpdateInfo<
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseExternalPluginUpdateInfo<
-  K extends BaseExternalPluginUpdateInfo['__kind']
+  K extends BaseExternalPluginUpdateInfo['__kind'],
 >(
   kind: K,
   value: BaseExternalPluginUpdateInfo

--- a/clients/js/src/generated/types/baseExternalPluginUpdateInfo.ts
+++ b/clients/js/src/generated/types/baseExternalPluginUpdateInfo.ts
@@ -91,7 +91,7 @@ export function baseExternalPluginUpdateInfo(
   >['fields']
 ): GetDataEnumKind<BaseExternalPluginUpdateInfoArgs, 'DataStore'>;
 export function baseExternalPluginUpdateInfo<
-  K extends BaseExternalPluginUpdateInfoArgs['__kind'],
+  K extends BaseExternalPluginUpdateInfoArgs['__kind']
 >(
   kind: K,
   data?: any
@@ -101,7 +101,7 @@ export function baseExternalPluginUpdateInfo<
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseExternalPluginUpdateInfo<
-  K extends BaseExternalPluginUpdateInfo['__kind'],
+  K extends BaseExternalPluginUpdateInfo['__kind']
 >(
   kind: K,
   value: BaseExternalPluginUpdateInfo

--- a/clients/js/src/generated/types/basePluginAuthority.ts
+++ b/clients/js/src/generated/types/basePluginAuthority.ts
@@ -60,7 +60,7 @@ export function basePluginAuthority(
   data: GetDataEnumKindContent<BasePluginAuthorityArgs, 'Address'>
 ): GetDataEnumKind<BasePluginAuthorityArgs, 'Address'>;
 export function basePluginAuthority<
-  K extends BasePluginAuthorityArgs['__kind'],
+  K extends BasePluginAuthorityArgs['__kind']
 >(kind: K, data?: any): Extract<BasePluginAuthorityArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }

--- a/clients/js/src/generated/types/basePluginAuthority.ts
+++ b/clients/js/src/generated/types/basePluginAuthority.ts
@@ -60,7 +60,7 @@ export function basePluginAuthority(
   data: GetDataEnumKindContent<BasePluginAuthorityArgs, 'Address'>
 ): GetDataEnumKind<BasePluginAuthorityArgs, 'Address'>;
 export function basePluginAuthority<
-  K extends BasePluginAuthorityArgs['__kind']
+  K extends BasePluginAuthorityArgs['__kind'],
 >(kind: K, data?: any): Extract<BasePluginAuthorityArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }

--- a/clients/js/src/generated/types/baseSeed.ts
+++ b/clients/js/src/generated/types/baseSeed.ts
@@ -6,12 +6,14 @@
  * @see https://github.com/metaplex-foundation/kinobi
  */
 
+import { PublicKey } from '@metaplex-foundation/umi';
 import {
   GetDataEnumKind,
   GetDataEnumKindContent,
   Serializer,
   bytes,
   dataEnum,
+  publicKey as publicKeySerializer,
   struct,
   tuple,
   u32,
@@ -19,11 +21,11 @@ import {
 } from '@metaplex-foundation/umi/serializers';
 
 export type BaseSeed =
-  | { __kind: 'Program' }
   | { __kind: 'Collection' }
   | { __kind: 'Owner' }
   | { __kind: 'Recipient' }
   | { __kind: 'Asset' }
+  | { __kind: 'Address'; fields: [PublicKey] }
   | { __kind: 'Bytes'; fields: [Uint8Array] };
 
 export type BaseSeedArgs = BaseSeed;
@@ -31,11 +33,16 @@ export type BaseSeedArgs = BaseSeed;
 export function getBaseSeedSerializer(): Serializer<BaseSeedArgs, BaseSeed> {
   return dataEnum<BaseSeed>(
     [
-      ['Program', unit()],
       ['Collection', unit()],
       ['Owner', unit()],
       ['Recipient', unit()],
       ['Asset', unit()],
+      [
+        'Address',
+        struct<GetDataEnumKindContent<BaseSeed, 'Address'>>([
+          ['fields', tuple([publicKeySerializer()])],
+        ]),
+      ],
       [
         'Bytes',
         struct<GetDataEnumKindContent<BaseSeed, 'Bytes'>>([
@@ -49,9 +56,6 @@ export function getBaseSeedSerializer(): Serializer<BaseSeedArgs, BaseSeed> {
 
 // Data Enum Helpers.
 export function baseSeed(
-  kind: 'Program'
-): GetDataEnumKind<BaseSeedArgs, 'Program'>;
-export function baseSeed(
   kind: 'Collection'
 ): GetDataEnumKind<BaseSeedArgs, 'Collection'>;
 export function baseSeed(kind: 'Owner'): GetDataEnumKind<BaseSeedArgs, 'Owner'>;
@@ -59,6 +63,10 @@ export function baseSeed(
   kind: 'Recipient'
 ): GetDataEnumKind<BaseSeedArgs, 'Recipient'>;
 export function baseSeed(kind: 'Asset'): GetDataEnumKind<BaseSeedArgs, 'Asset'>;
+export function baseSeed(
+  kind: 'Address',
+  data: GetDataEnumKindContent<BaseSeedArgs, 'Address'>['fields']
+): GetDataEnumKind<BaseSeedArgs, 'Address'>;
 export function baseSeed(
   kind: 'Bytes',
   data: GetDataEnumKindContent<BaseSeedArgs, 'Bytes'>['fields']

--- a/clients/js/src/generated/types/baseUpdateAuthority.ts
+++ b/clients/js/src/generated/types/baseUpdateAuthority.ts
@@ -62,7 +62,7 @@ export function baseUpdateAuthority(
   data: GetDataEnumKindContent<BaseUpdateAuthorityArgs, 'Collection'>['fields']
 ): GetDataEnumKind<BaseUpdateAuthorityArgs, 'Collection'>;
 export function baseUpdateAuthority<
-  K extends BaseUpdateAuthorityArgs['__kind'],
+  K extends BaseUpdateAuthorityArgs['__kind']
 >(kind: K, data?: any): Extract<BaseUpdateAuthorityArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }

--- a/clients/js/src/generated/types/baseUpdateAuthority.ts
+++ b/clients/js/src/generated/types/baseUpdateAuthority.ts
@@ -62,7 +62,7 @@ export function baseUpdateAuthority(
   data: GetDataEnumKindContent<BaseUpdateAuthorityArgs, 'Collection'>['fields']
 ): GetDataEnumKind<BaseUpdateAuthorityArgs, 'Collection'>;
 export function baseUpdateAuthority<
-  K extends BaseUpdateAuthorityArgs['__kind']
+  K extends BaseUpdateAuthorityArgs['__kind'],
 >(kind: K, data?: any): Extract<BaseUpdateAuthorityArgs, { __kind: K }> {
   return Array.isArray(data)
     ? { __kind: kind, fields: data }

--- a/clients/js/src/generated/types/baseValidationResultsOffset.ts
+++ b/clients/js/src/generated/types/baseValidationResultsOffset.ts
@@ -61,7 +61,7 @@ export function baseValidationResultsOffset(
   >['fields']
 ): GetDataEnumKind<BaseValidationResultsOffsetArgs, 'Custom'>;
 export function baseValidationResultsOffset<
-  K extends BaseValidationResultsOffsetArgs['__kind']
+  K extends BaseValidationResultsOffsetArgs['__kind'],
 >(
   kind: K,
   data?: any
@@ -71,7 +71,7 @@ export function baseValidationResultsOffset<
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseValidationResultsOffset<
-  K extends BaseValidationResultsOffset['__kind']
+  K extends BaseValidationResultsOffset['__kind'],
 >(
   kind: K,
   value: BaseValidationResultsOffset

--- a/clients/js/src/generated/types/baseValidationResultsOffset.ts
+++ b/clients/js/src/generated/types/baseValidationResultsOffset.ts
@@ -61,7 +61,7 @@ export function baseValidationResultsOffset(
   >['fields']
 ): GetDataEnumKind<BaseValidationResultsOffsetArgs, 'Custom'>;
 export function baseValidationResultsOffset<
-  K extends BaseValidationResultsOffsetArgs['__kind'],
+  K extends BaseValidationResultsOffsetArgs['__kind']
 >(
   kind: K,
   data?: any
@@ -71,7 +71,7 @@ export function baseValidationResultsOffset<
     : { __kind: kind, ...(data ?? {}) };
 }
 export function isBaseValidationResultsOffset<
-  K extends BaseValidationResultsOffset['__kind'],
+  K extends BaseValidationResultsOffset['__kind']
 >(
   kind: K,
   value: BaseValidationResultsOffset

--- a/clients/js/src/hooked/pluginRegistryV1Data.ts
+++ b/clients/js/src/hooked/pluginRegistryV1Data.ts
@@ -134,7 +134,10 @@ export function getExternalRegistryRecordSerializer(): Serializer<
         lifecycleChecksOffset
       );
 
-      const [dataOffset, dataOffsetOffset] = option(u64()).deserialize(buffer, pluginOffsetOffset);
+      const [dataOffset, dataOffsetOffset] = option(u64()).deserialize(
+        buffer,
+        pluginOffsetOffset
+      );
       const [dataLen] = option(u64()).deserialize(buffer, dataOffsetOffset);
       return [
         {

--- a/clients/js/src/plugins/externalPluginManifest.ts
+++ b/clients/js/src/plugins/externalPluginManifest.ts
@@ -10,7 +10,11 @@ export type ExternalPluginManifest<
   UpdateBase extends Object
 > = {
   type: ExternalPluginTypeString;
-  fromBase: (input: Base, record: ExternalRegistryRecord, account: Uint8Array) => T;
+  fromBase: (
+    input: Base,
+    record: ExternalRegistryRecord,
+    account: Uint8Array
+  ) => T;
   initToBase: (input: Init) => InitBase;
   updateToBase: (input: Update) => UpdateBase;
 };

--- a/clients/js/src/plugins/externalPlugins.ts
+++ b/clients/js/src/plugins/externalPlugins.ts
@@ -1,4 +1,9 @@
-import { AccountMeta, Context, PublicKey, Option } from '@metaplex-foundation/umi';
+import {
+  AccountMeta,
+  Context,
+  PublicKey,
+  Option,
+} from '@metaplex-foundation/umi';
 import {
   lifecycleHookFromBase,
   LifecycleHookInitInfoArgs,
@@ -50,25 +55,25 @@ export type ExternalPluginsList = {
 
 export type ExternalPluginInitInfoArgs =
   | ({
-    type: 'Oracle';
-  } & OracleInitInfoArgs)
+      type: 'Oracle';
+    } & OracleInitInfoArgs)
   | ({
-    type: 'LifecycleHook';
-  } & LifecycleHookInitInfoArgs)
+      type: 'LifecycleHook';
+    } & LifecycleHookInitInfoArgs)
   | ({
-    type: 'DataStore';
-  } & DataStoreInitInfoArgs);
+      type: 'DataStore';
+    } & DataStoreInitInfoArgs);
 
 export type ExternalPluginUpdateInfoArgs =
   | ({
-    type: 'Oracle';
-  } & OracleUpdateInfoArgs)
+      type: 'Oracle';
+    } & OracleUpdateInfoArgs)
   | ({
-    type: 'LifecycleHook';
-  } & LifecycleHookUpdateInfoArgs)
+      type: 'LifecycleHook';
+    } & LifecycleHookUpdateInfoArgs)
   | ({
-    type: 'DataStore';
-  } & DataStoreUpdateInfoArgs);
+      type: 'DataStore';
+    } & DataStoreUpdateInfoArgs);
 
 export const externalPluginManifests = {
   Oracle: oracleManifest,
@@ -128,7 +133,11 @@ export function externalRegistryRecordsToExternalPluginList(
       result.lifecycleHooks.push({
         type: 'LifecycleHook',
         ...mappedPlugin,
-        ...lifecycleHookFromBase(deserializedPlugin.fields[0], record, accountData),
+        ...lifecycleHookFromBase(
+          deserializedPlugin.fields[0],
+          record,
+          accountData
+        ),
       });
     }
   });

--- a/clients/js/src/plugins/extraAccount.ts
+++ b/clients/js/src/plugins/extraAccount.ts
@@ -119,13 +119,10 @@ export function extraAccountToAccountMeta(
               case 'Asset':
                 if (!inputs.asset) throw new Error('Asset address is required');
                 return publicKeySerializer().serialize(inputs.asset);
+              case 'Address':
+                  return publicKeySerializer().serialize(seed.pubkey);
               case 'Bytes':
                 return seed.bytes;
-              case 'Program':
-              default:
-                if (!inputs.program)
-                  throw new Error('Program address is required');
-                return publicKeySerializer().serialize(inputs.program);
             }
           })
         )[0],

--- a/clients/js/src/plugins/extraAccount.ts
+++ b/clients/js/src/plugins/extraAccount.ts
@@ -120,7 +120,7 @@ export function extraAccountToAccountMeta(
                 if (!inputs.asset) throw new Error('Asset address is required');
                 return publicKeySerializer().serialize(inputs.asset);
               case 'Address':
-                  return publicKeySerializer().serialize(seed.pubkey);
+                return publicKeySerializer().serialize(seed.pubkey);
               case 'Bytes':
                 return seed.bytes;
             }

--- a/clients/js/src/plugins/lib.ts
+++ b/clients/js/src/plugins/lib.ts
@@ -26,7 +26,6 @@ import {
 import { royaltiesFromBase, royaltiesToBase } from './royalties';
 import { masterEditionFromBase, masterEditionToBase } from './masterEdition';
 
-
 export function formPluginHeaderV1(
   pluginRegistryOffset: bigint
 ): Omit<PluginHeaderV1, 'publicKey' | 'header'> {

--- a/clients/js/src/plugins/masterEdition.ts
+++ b/clients/js/src/plugins/masterEdition.ts
@@ -1,27 +1,26 @@
-import { BaseMasterEdition } from "../generated";
-import { someOrNone, unwrapOption } from "../utils";
-
+import { BaseMasterEdition } from '../generated';
+import { someOrNone, unwrapOption } from '../utils';
 
 export type MasterEdition = {
   maxSupply?: number;
-  name?: string
-  uri?: string
-}
+  name?: string;
+  uri?: string;
+};
 
-export type MasterEditionArgs = MasterEdition
+export type MasterEditionArgs = MasterEdition;
 
 export function masterEditionToBase(s: MasterEdition): BaseMasterEdition {
   return {
     maxSupply: someOrNone(s.maxSupply),
     name: someOrNone(s.name),
-    uri: someOrNone(s.uri)
-  }
+    uri: someOrNone(s.uri),
+  };
 }
 
 export function masterEditionFromBase(s: BaseMasterEdition): MasterEdition {
   return {
     maxSupply: unwrapOption(s.maxSupply),
     name: unwrapOption(s.name),
-    uri: unwrapOption( s.uri)
-  }
+    uri: unwrapOption(s.uri),
+  };
 }

--- a/clients/js/src/plugins/oracle.ts
+++ b/clients/js/src/plugins/oracle.ts
@@ -83,7 +83,11 @@ export function oracleUpdateInfoArgsToBase(
   };
 }
 
-export function oracleFromBase(s: BaseOracle, r: ExternalRegistryRecord, account: Uint8Array): Oracle {
+export function oracleFromBase(
+  s: BaseOracle,
+  r: ExternalRegistryRecord,
+  account: Uint8Array
+): Oracle {
   return {
     ...s,
     pda:

--- a/clients/js/src/plugins/seed.ts
+++ b/clients/js/src/plugins/seed.ts
@@ -1,14 +1,26 @@
 import { BaseSeed } from '../generated';
 import { RenameToType } from '../utils';
+import { PublicKey } from '@metaplex-foundation/umi';
 
 export type Seed =
-  | Exclude<RenameToType<BaseSeed>, { type: 'Bytes' }>
+  | Exclude<RenameToType<BaseSeed>, { type: 'Address' } | { type: 'Bytes' }>
+  | {
+      type: 'Address';
+      pubkey: PublicKey;
+    }
   | {
       type: 'Bytes';
       bytes: Uint8Array;
     };
 
 export function seedToBase(s: Seed): BaseSeed {
+  if (s.type === 'Address') {
+    return {
+      __kind: 'Address',
+      fields: [s.pubkey],
+    };
+  }
+
   if (s.type === 'Bytes') {
     return {
       __kind: 'Bytes',
@@ -21,6 +33,12 @@ export function seedToBase(s: Seed): BaseSeed {
 }
 
 export function seedFromBase(s: BaseSeed): Seed {
+  if (s.__kind === 'Address') {
+    return {
+      type: 'Address',
+      pubkey: s.fields[0],
+    };
+  }
   if (s.__kind === 'Bytes') {
     return {
       type: 'Bytes',

--- a/clients/js/src/plugins/types.ts
+++ b/clients/js/src/plugins/types.ts
@@ -74,9 +74,9 @@ export type CreatePluginArgs =
       data: EditionArgs;
     }
   | {
-    type: 'MasterEdition';
-    data: BaseMasterEditionArgs
-  };
+      type: 'MasterEdition';
+      data: BaseMasterEditionArgs;
+    };
 
 export type AuthorityArgsV2 = {
   authority?: PluginAuthority;
@@ -116,8 +116,8 @@ export type AddablePluginArgsV2 =
       type: 'Attributes';
     } & AttributesArgs)
   | ({
-      type: 'MasterEdition'
-  } & MasterEditionArgs)
+      type: 'MasterEdition';
+    } & MasterEditionArgs);
 
 export type PluginArgsV2 = AddablePluginArgsV2 | CreateOnlyPluginArgsV2;
 export type PluginAuthorityPairArgsV2 = PluginArgsV2 & AuthorityArgsV2;

--- a/clients/js/src/utils.ts
+++ b/clients/js/src/utils.ts
@@ -1,4 +1,4 @@
-import { none, Option, some } from "@metaplex-foundation/umi";
+import { none, Option, some } from '@metaplex-foundation/umi';
 
 export type RenameField<T, K extends keyof T, R extends PropertyKey> = Omit<
   T,

--- a/clients/js/test/sdkv1.test.ts
+++ b/clients/js/test/sdkv1.test.ts
@@ -80,7 +80,7 @@ test('it can create asset and collection with all update auth managed party plug
         maxSupply: 100,
         name: 'master',
         uri: 'uri master',
-      }
+      },
     ],
   });
 
@@ -138,7 +138,7 @@ test('it can create asset and collection with all update auth managed party plug
       maxSupply: 100,
       name: 'master',
       uri: 'uri master',
-    }
+    },
   });
 
   const asset = await createAsset(umi, {
@@ -706,7 +706,7 @@ test('it can update all updatable plugins on collection', async (t) => {
         maxSupply: 100,
         name: 'master',
         uri: 'uri master',
-      }
+      },
     ],
   });
 
@@ -743,7 +743,7 @@ test('it can update all updatable plugins on collection', async (t) => {
       maxSupply: 200,
       name: 'master2',
       uri: 'uri master2',
-    }
+    },
   ];
 
   await Promise.all(
@@ -797,7 +797,7 @@ test('it can update all updatable plugins on collection', async (t) => {
       maxSupply: 200,
       name: 'master2',
       uri: 'uri master2',
-    }
+    },
   });
 });
 

--- a/clients/rust/src/generated/types/seed.rs
+++ b/clients/rust/src/generated/types/seed.rs
@@ -7,14 +7,19 @@
 
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
+use solana_program::pubkey::Pubkey;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Seed {
-    Program,
     Collection,
     Owner,
     Recipient,
     Asset,
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "serde_with::As::<serde_with::DisplayFromStr>")
+    )]
+    Address(Pubkey),
     Bytes(Vec<u8>),
 }

--- a/idls/mpl_core.json
+++ b/idls/mpl_core.json
@@ -3642,9 +3642,6 @@
         "kind": "enum",
         "variants": [
           {
-            "name": "Program"
-          },
-          {
             "name": "Collection"
           },
           {
@@ -3655,6 +3652,12 @@
           },
           {
             "name": "Asset"
+          },
+          {
+            "name": "Address",
+            "fields": [
+              "publicKey"
+            ]
           },
           {
             "name": "Bytes",

--- a/programs/mpl-core/src/processor/update_external_plugin.rs
+++ b/programs/mpl-core/src/processor/update_external_plugin.rs
@@ -59,6 +59,7 @@ pub(crate) fn update_external_plugin<'a>(
         fetch_wrapped_external_plugin::<AssetV1>(ctx.accounts.asset, None, &args.key)?;
 
     let (mut asset, plugin_header, plugin_registry) = validate_asset_permissions(
+        accounts,
         authority,
         ctx.accounts.asset,
         ctx.accounts.collection,
@@ -198,6 +199,7 @@ pub(crate) fn update_collection_external_plugin<'a>(
 
     // Validate collection permissions.
     let (collection, plugin_header, plugin_registry) = validate_collection_permissions(
+        accounts,
         authority,
         ctx.accounts.collection,
         None,


### PR DESCRIPTION
### Program changes:
* Add `Seed::Address(pubkey)` for the commun use case of using a `Pubkey` as as seed.
* Remove program `Seed` as it's redundant to the fact that the program ID is inherently already a seed to the user's PDA.

### JS SDK changes:
* Update `Seed` type
* Update `extraAccountToAccountMeta`, note it does not have a default now, not sure if that is needed but wasn't sure what to set it to.