### PR TITLE
Prevent Oracle from approving lifecycle events

### DIFF
--- a/clients/js/src/generated/errors/mplCore.ts
+++ b/clients/js/src/generated/errors/mplCore.ts
@@ -492,6 +492,22 @@ export class MissingExternalAccountError extends ProgramError {
 codeToErrorMap.set(0x22, MissingExternalAccountError);
 nameToErrorMap.set('MissingExternalAccount', MissingExternalAccountError);
 
+/** InvalidExternalPluginSetting: Invalid setting for external plugin */
+export class InvalidExternalPluginSettingError extends ProgramError {
+  override readonly name: string = 'InvalidExternalPluginSetting';
+
+  readonly code: number = 0x23; // 35
+
+  constructor(program: Program, cause?: Error) {
+    super('Invalid setting for external plugin', program, cause);
+  }
+}
+codeToErrorMap.set(0x23, InvalidExternalPluginSettingError);
+nameToErrorMap.set(
+  'InvalidExternalPluginSetting',
+  InvalidExternalPluginSettingError
+);
+
 /**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors

--- a/clients/rust/src/generated/errors/mpl_core.rs
+++ b/clients/rust/src/generated/errors/mpl_core.rs
@@ -115,6 +115,9 @@ pub enum MplCoreError {
     /// 34 (0x22) - Missing account needed for external plugin
     #[error("Missing account needed for external plugin")]
     MissingExternalAccount,
+    /// 35 (0x23) - Invalid setting for external plugin
+    #[error("Invalid setting for external plugin")]
+    InvalidExternalPluginSetting,
 }
 
 impl solana_program::program_error::PrintProgramError for MplCoreError {

--- a/idls/mpl_core.json
+++ b/idls/mpl_core.json
@@ -4163,6 +4163,11 @@
       "code": 34,
       "name": "MissingExternalAccount",
       "msg": "Missing account needed for external plugin"
+    },
+    {
+      "code": 35,
+      "name": "InvalidExternalPluginSetting",
+      "msg": "Invalid setting for external plugin"
     }
   ],
   "metadata": {

--- a/programs/mpl-core/src/error.rs
+++ b/programs/mpl-core/src/error.rs
@@ -148,6 +148,10 @@ pub enum MplCoreError {
     /// 34 - Missing account needed for external plugin
     #[error("Missing account needed for external plugin")]
     MissingExternalAccount,
+
+    /// 35 - Invalid setting for external plugin
+    #[error("Invalid setting for external plugin")]
+    InvalidExternalPluginSetting,
 }
 
 impl PrintProgramError for MplCoreError {

--- a/programs/mpl-core/src/error.rs
+++ b/programs/mpl-core/src/error.rs
@@ -149,9 +149,9 @@ pub enum MplCoreError {
     #[error("Missing account needed for external plugin")]
     MissingExternalAccount,
 
-    /// 35 - Invalid setting for external plugin
-    #[error("Invalid setting for external plugin")]
-    InvalidExternalPluginSetting,
+    /// 35 - Oracle external plugin can only be configured to deny
+    #[error("Oracle external plugin can only be configured to deny")]
+    OracleCanDenyOnly,
 }
 
 impl PrintProgramError for MplCoreError {

--- a/programs/mpl-core/src/plugins/utils.rs
+++ b/programs/mpl-core/src/plugins/utils.rs
@@ -334,8 +334,9 @@ pub fn initialize_external_plugin<'a, T: DataBlob + SolanaAccount>(
             // You cannot configure an Oracle plugin to approve lifecycle events.
             if let Some(lifecycle_checks) = &init_info.lifecycle_checks {
                 for (_, result) in lifecycle_checks {
-                    if ExternalCheckResultBits::from(*result).can_approve() {
-                        return Err(MplCoreError::InvalidExternalPluginSetting.into());
+                    let result_bits = ExternalCheckResultBits::from(*result);
+                    if result_bits.can_listen() || result_bits.can_approve() {
+                        return Err(MplCoreError::OracleCanDenyOnly.into());
                     }
                 }
             }


### PR DESCRIPTION
Block when initializing external plugins.

Open question: Should we disallow `CAN_LISTEN` as well for Oracle, as it is completely ineffective?

Tested on https://github.com/metaplex-foundation/mpl-core/pull/90 but I have one question for @nhanphan before that branch can be updated.