### PR TITLE
Prevent duplicate lifecycle checks in external plugins

### DIFF
--- a/clients/js/src/generated/errors/mplCore.ts
+++ b/clients/js/src/generated/errors/mplCore.ts
@@ -509,25 +509,39 @@ export class OracleCanRejectOnlyError extends ProgramError {
 codeToErrorMap.set(0x23, OracleCanRejectOnlyError);
 nameToErrorMap.set('OracleCanRejectOnly', OracleCanRejectOnlyError);
 
-/** OracleRequiresLifecycleCheck: Oracle external plugin must have at least one lifecycle check */
-export class OracleRequiresLifecycleCheckError extends ProgramError {
-  override readonly name: string = 'OracleRequiresLifecycleCheck';
+/** RequiresLifecycleCheck: External plugin must have at least one lifecycle check */
+export class RequiresLifecycleCheckError extends ProgramError {
+  override readonly name: string = 'RequiresLifecycleCheck';
 
   readonly code: number = 0x24; // 36
 
   constructor(program: Program, cause?: Error) {
     super(
-      'Oracle external plugin must have at least one lifecycle check',
+      'External plugin must have at least one lifecycle check',
       program,
       cause
     );
   }
 }
-codeToErrorMap.set(0x24, OracleRequiresLifecycleCheckError);
-nameToErrorMap.set(
-  'OracleRequiresLifecycleCheck',
-  OracleRequiresLifecycleCheckError
-);
+codeToErrorMap.set(0x24, RequiresLifecycleCheckError);
+nameToErrorMap.set('RequiresLifecycleCheck', RequiresLifecycleCheckError);
+
+/** DuplicateLifecycleChecks: Duplicate lifecycle checks were provided for external plugin  */
+export class DuplicateLifecycleChecksError extends ProgramError {
+  override readonly name: string = 'DuplicateLifecycleChecks';
+
+  readonly code: number = 0x25; // 37
+
+  constructor(program: Program, cause?: Error) {
+    super(
+      'Duplicate lifecycle checks were provided for external plugin ',
+      program,
+      cause
+    );
+  }
+}
+codeToErrorMap.set(0x25, DuplicateLifecycleChecksError);
+nameToErrorMap.set('DuplicateLifecycleChecks', DuplicateLifecycleChecksError);
 
 /**
  * Attempts to resolve a custom program error from the provided error code.

--- a/clients/js/test/externalPlugins/oracle.test.ts
+++ b/clients/js/test/externalPlugins/oracle.test.ts
@@ -282,7 +282,7 @@ test('it cannot create asset with oracle that has no lifecycle checks', async (t
     ],
   });
 
-  await t.throwsAsync(result, { name: 'OracleRequiresLifecycleCheck' });
+  await t.throwsAsync(result, { name: 'RequiresLifecycleCheck' });
 });
 
 test('it cannot add oracle with no lifecycle checks to asset', async (t) => {
@@ -313,7 +313,7 @@ test('it cannot add oracle with no lifecycle checks to asset', async (t) => {
     },
   }).sendAndConfirm(umi);
 
-  await t.throwsAsync(result, { name: 'OracleRequiresLifecycleCheck' });
+  await t.throwsAsync(result, { name: 'RequiresLifecycleCheck' });
 
   await assertAsset(t, umi, {
     ...DEFAULT_ASSET,

--- a/clients/rust/src/generated/errors/mpl_core.rs
+++ b/clients/rust/src/generated/errors/mpl_core.rs
@@ -118,9 +118,12 @@ pub enum MplCoreError {
     /// 35 (0x23) - Oracle external plugin can only be configured to reject
     #[error("Oracle external plugin can only be configured to reject")]
     OracleCanRejectOnly,
-    /// 36 (0x24) - Oracle external plugin must have at least one lifecycle check
-    #[error("Oracle external plugin must have at least one lifecycle check")]
-    OracleRequiresLifecycleCheck,
+    /// 36 (0x24) - External plugin must have at least one lifecycle check
+    #[error("External plugin must have at least one lifecycle check")]
+    RequiresLifecycleCheck,
+    /// 37 (0x25) - Duplicate lifecycle checks were provided for external plugin
+    #[error("Duplicate lifecycle checks were provided for external plugin ")]
+    DuplicateLifecycleChecks,
 }
 
 impl solana_program::program_error::PrintProgramError for MplCoreError {

--- a/clients/rust/tests/add_external_plugins.rs
+++ b/clients/rust/tests/add_external_plugins.rs
@@ -103,6 +103,100 @@ async fn test_add_lifecycle_hook() {
 }
 
 #[tokio::test]
+async fn test_cannot_add_lifecycle_hook_with_duplicate_lifecycle_checks() {
+    let mut context = program_test().start_with_context().await;
+
+    let asset = Keypair::new();
+    create_asset(
+        &mut context,
+        CreateAssetHelperArgs {
+            owner: None,
+            payer: None,
+            asset: &asset,
+            data_state: None,
+            name: None,
+            uri: None,
+            authority: None,
+            update_authority: None,
+            collection: None,
+            plugins: vec![],
+            external_plugins: vec![],
+        },
+    )
+    .await
+    .unwrap();
+
+    let owner = context.payer.pubkey();
+    let update_authority = context.payer.pubkey();
+    assert_asset(
+        &mut context,
+        AssertAssetHelperArgs {
+            asset: asset.pubkey(),
+            owner,
+            update_authority: Some(UpdateAuthority::Address(update_authority)),
+            name: None,
+            uri: None,
+            plugins: vec![],
+            external_plugins: vec![],
+        },
+    )
+    .await;
+
+    let add_external_plugin_ix = AddExternalPluginV1Builder::new()
+        .asset(asset.pubkey())
+        .payer(context.payer.pubkey())
+        .init_info(ExternalPluginInitInfo::LifecycleHook(
+            LifecycleHookInitInfo {
+                hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+                init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
+                lifecycle_checks: Some(vec![
+                    (
+                        HookableLifecycleEvent::Transfer,
+                        ExternalCheckResult { flags: 1 },
+                    ),
+                    (
+                        HookableLifecycleEvent::Transfer,
+                        ExternalCheckResult { flags: 1 },
+                    ),
+                ]),
+                extra_accounts: None,
+                data_authority: Some(PluginAuthority::UpdateAuthority),
+                schema: None,
+            },
+        ))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[add_external_plugin_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    assert_custom_instruction_error!(0, error, MplCoreError::DuplicateLifecycleChecks);
+
+    assert_asset(
+        &mut context,
+        AssertAssetHelperArgs {
+            asset: asset.pubkey(),
+            owner,
+            update_authority: Some(UpdateAuthority::Address(update_authority)),
+            name: None,
+            uri: None,
+            plugins: vec![],
+            external_plugins: vec![],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_add_oracle() {
     let mut context = program_test().start_with_context().await;
 
@@ -180,6 +274,97 @@ async fn test_add_oracle() {
                 pda: None,
                 results_offset: ValidationResultsOffset::NoOffset,
             })],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_cannot_add_oracle_with_duplicate_lifecycle_checks() {
+    let mut context = program_test().start_with_context().await;
+
+    let asset = Keypair::new();
+    create_asset(
+        &mut context,
+        CreateAssetHelperArgs {
+            owner: None,
+            payer: None,
+            asset: &asset,
+            data_state: None,
+            name: None,
+            uri: None,
+            authority: None,
+            update_authority: None,
+            collection: None,
+            plugins: vec![],
+            external_plugins: vec![],
+        },
+    )
+    .await
+    .unwrap();
+
+    let owner = context.payer.pubkey();
+    let update_authority = context.payer.pubkey();
+    assert_asset(
+        &mut context,
+        AssertAssetHelperArgs {
+            asset: asset.pubkey(),
+            owner,
+            update_authority: Some(UpdateAuthority::Address(update_authority)),
+            name: None,
+            uri: None,
+            plugins: vec![],
+            external_plugins: vec![],
+        },
+    )
+    .await;
+
+    let add_external_plugin_ix = AddExternalPluginV1Builder::new()
+        .asset(asset.pubkey())
+        .payer(context.payer.pubkey())
+        .init_info(ExternalPluginInitInfo::Oracle(OracleInitInfo {
+            base_address: Pubkey::default(),
+            init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
+            lifecycle_checks: vec![
+                (
+                    HookableLifecycleEvent::Transfer,
+                    ExternalCheckResult { flags: 4 },
+                ),
+                (
+                    HookableLifecycleEvent::Transfer,
+                    ExternalCheckResult { flags: 4 },
+                ),
+            ],
+            pda: None,
+            results_offset: None,
+        }))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[add_external_plugin_ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    assert_custom_instruction_error!(0, error, MplCoreError::DuplicateLifecycleChecks);
+
+    assert_asset(
+        &mut context,
+        AssertAssetHelperArgs {
+            asset: asset.pubkey(),
+            owner,
+            update_authority: Some(UpdateAuthority::Address(update_authority)),
+            name: None,
+            uri: None,
+            plugins: vec![],
+            external_plugins: vec![],
         },
     )
     .await;

--- a/idls/mpl_core.json
+++ b/idls/mpl_core.json
@@ -4169,8 +4169,13 @@
     },
     {
       "code": 36,
-      "name": "OracleRequiresLifecycleCheck",
-      "msg": "Oracle external plugin must have at least one lifecycle check"
+      "name": "RequiresLifecycleCheck",
+      "msg": "External plugin must have at least one lifecycle check"
+    },
+    {
+      "code": 37,
+      "name": "DuplicateLifecycleChecks",
+      "msg": "Duplicate lifecycle checks were provided for external plugin "
     }
   ],
   "metadata": {

--- a/programs/mpl-core/src/error.rs
+++ b/programs/mpl-core/src/error.rs
@@ -153,9 +153,13 @@ pub enum MplCoreError {
     #[error("Oracle external plugin can only be configured to reject")]
     OracleCanRejectOnly,
 
-    /// 36 - Oracle external plugin must have at least one lifecycle check
-    #[error("Oracle external plugin must have at least one lifecycle check")]
-    OracleRequiresLifecycleCheck,
+    /// 36 - External plugin must have at least one lifecycle check
+    #[error("External plugin must have at least one lifecycle check")]
+    RequiresLifecycleCheck,
+
+    /// 37 - Duplicate lifecycle checks were provided for external plugin
+    #[error("Duplicate lifecycle checks were provided for external plugin ")]
+    DuplicateLifecycleChecks,
 }
 
 impl PrintProgramError for MplCoreError {


### PR DESCRIPTION
Tested in Rust because I don't think I could easily do it with JS client.

Also changed `OracleRequiresLifecycleCheck` to just `RequiresLifecycleCheck` as it now will apply to Lifecycle Hook as well.