### PR TITLE
Danenbm/lifecycle check requirements

### DIFF
--- a/clients/js/src/generated/types/baseLifecycleHookInitInfo.ts
+++ b/clients/js/src/generated/types/baseLifecycleHookInitInfo.ts
@@ -36,7 +36,7 @@ import {
 export type BaseLifecycleHookInitInfo = {
   hookedProgram: PublicKey;
   initPluginAuthority: Option<BasePluginAuthority>;
-  lifecycleChecks: Option<Array<[HookableLifecycleEvent, ExternalCheckResult]>>;
+  lifecycleChecks: Array<[HookableLifecycleEvent, ExternalCheckResult]>;
   extraAccounts: Option<Array<BaseExtraAccount>>;
   dataAuthority: Option<BasePluginAuthority>;
   schema: Option<ExternalPluginSchema>;
@@ -45,9 +45,7 @@ export type BaseLifecycleHookInitInfo = {
 export type BaseLifecycleHookInitInfoArgs = {
   hookedProgram: PublicKey;
   initPluginAuthority: OptionOrNullable<BasePluginAuthorityArgs>;
-  lifecycleChecks: OptionOrNullable<
-    Array<[HookableLifecycleEventArgs, ExternalCheckResultArgs]>
-  >;
+  lifecycleChecks: Array<[HookableLifecycleEventArgs, ExternalCheckResultArgs]>;
   extraAccounts: OptionOrNullable<Array<BaseExtraAccountArgs>>;
   dataAuthority: OptionOrNullable<BasePluginAuthorityArgs>;
   schema: OptionOrNullable<ExternalPluginSchemaArgs>;
@@ -63,13 +61,11 @@ export function getBaseLifecycleHookInitInfoSerializer(): Serializer<
       ['initPluginAuthority', option(getBasePluginAuthoritySerializer())],
       [
         'lifecycleChecks',
-        option(
-          array(
-            tuple([
-              getHookableLifecycleEventSerializer(),
-              getExternalCheckResultSerializer(),
-            ])
-          )
+        array(
+          tuple([
+            getHookableLifecycleEventSerializer(),
+            getExternalCheckResultSerializer(),
+          ])
         ),
       ],
       ['extraAccounts', option(array(getBaseExtraAccountSerializer()))],

--- a/clients/js/src/plugins/dataStore.ts
+++ b/clients/js/src/plugins/dataStore.ts
@@ -7,7 +7,8 @@ import {
 } from '../generated';
 import { ExternalPluginKey } from './externalPluginKey';
 import { ExternalPluginManifest } from './externalPluginManifest';
-import { BaseExternalPlugin, parseExternalPluginData } from './externalPlugins';
+import { BaseExternalPlugin } from './externalPlugins';
+import { parseExternalPluginData } from './lib';
 import { LifecycleChecks } from './lifecycleChecks';
 import {
   PluginAuthority,

--- a/clients/js/src/plugins/externalPlugins.ts
+++ b/clients/js/src/plugins/externalPlugins.ts
@@ -1,9 +1,4 @@
-import {
-  AccountMeta,
-  Context,
-  PublicKey,
-  Option,
-} from '@metaplex-foundation/umi';
+import { AccountMeta, Context, PublicKey } from '@metaplex-foundation/umi';
 import {
   lifecycleHookFromBase,
   LifecycleHookInitInfoArgs,
@@ -16,7 +11,6 @@ import {
   BaseExternalPluginInitInfoArgs,
   BaseExternalPluginKey,
   BaseExternalPluginUpdateInfoArgs,
-  ExternalPluginSchema,
   ExternalRegistryRecord,
   getExternalPluginSerializer,
 } from '../generated';
@@ -231,33 +225,3 @@ export const findExtraAccounts = (
 
   return accounts;
 };
-
-export function parseExternalPluginData(
-  plugin: {
-    schema: ExternalPluginSchema;
-  },
-  record: {
-    dataLen: Option<bigint | number>;
-    dataOffset: Option<bigint | number>;
-  },
-  account: Uint8Array
-): any {
-  let data;
-  const dataSlice = account.slice(
-    Number(record.dataOffset),
-    Number(record.dataOffset) + Number(record.dataLen)
-  );
-
-  if (plugin.schema === ExternalPluginSchema.Binary) {
-    data = dataSlice;
-  } else if (plugin.schema === ExternalPluginSchema.Json) {
-    data = JSON.parse(new TextDecoder().decode(dataSlice));
-  } else if (plugin.schema === ExternalPluginSchema.MsgPack) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'MsgPack schema currently not supported, falling back to binary'
-    );
-    data = dataSlice;
-  }
-  return data;
-}

--- a/clients/js/src/plugins/lifecycleHook.ts
+++ b/clients/js/src/plugins/lifecycleHook.ts
@@ -42,7 +42,7 @@ export type LifecycleHookInitInfoArgs = Omit<
 > & {
   type: 'LifecycleHook';
   initPluginAuthority?: PluginAuthority;
-  lifecycleChecks?: LifecycleChecks;
+  lifecycleChecks: LifecycleChecks;
   schema?: ExternalPluginSchema;
   extraAccounts?: Array<ExtraAccount>;
   dataAuthority?: PluginAuthority;
@@ -69,9 +69,7 @@ export function lifecycleHookInitInfoArgsToBase(
     initPluginAuthority: l.initPluginAuthority
       ? pluginAuthorityToBase(l.initPluginAuthority)
       : null,
-    lifecycleChecks: l.lifecycleChecks
-      ? lifecycleChecksToBase(l.lifecycleChecks)
-      : null,
+    lifecycleChecks: lifecycleChecksToBase(l.lifecycleChecks),
     schema: l.schema ? l.schema : null,
     dataAuthority: l.dataAuthority
       ? pluginAuthorityToBase(l.dataAuthority)

--- a/clients/js/src/plugins/lifecycleHook.ts
+++ b/clients/js/src/plugins/lifecycleHook.ts
@@ -38,7 +38,11 @@ export type LifecycleHookPlugin = BaseExternalPlugin &
 
 export type LifecycleHookInitInfoArgs = Omit<
   BaseLifecycleHookInitInfoArgs,
-  'initPluginAuthority' | 'lifecycleChecks' | 'schema' | 'dataAuthority'
+  | 'initPluginAuthority'
+  | 'lifecycleChecks'
+  | 'schema'
+  | 'extraAccounts'
+  | 'dataAuthority'
 > & {
   type: 'LifecycleHook';
   initPluginAuthority?: PluginAuthority;

--- a/clients/js/src/plugins/lifecycleHook.ts
+++ b/clients/js/src/plugins/lifecycleHook.ts
@@ -17,9 +17,10 @@ import {
   pluginAuthorityFromBase,
   pluginAuthorityToBase,
 } from './pluginAuthority';
-import { BaseExternalPlugin, parseExternalPluginData } from './externalPlugins';
+import { BaseExternalPlugin } from './externalPlugins';
 import { ExternalPluginManifest } from './externalPluginManifest';
 import { ExternalPluginKey } from './externalPluginKey';
+import { parseExternalPluginData } from './lib';
 
 export type LifecycleHook = Omit<
   BaseLifecycleHook,

--- a/clients/js/test/externalPlugins/lifecycleHook.test.ts
+++ b/clients/js/test/externalPlugins/lifecycleHook.test.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_ASSET,
 } from '../_setupRaw';
 import { createAsset } from '../_setupSdk';
-import { addPlugin, updatePlugin } from '../../src';
+import { addPlugin, CheckResult, updatePlugin } from '../../src';
 
 const createUmi = async () =>
   (await baseCreateUmi()).use(mplCoreOracleExample());
@@ -74,6 +74,15 @@ test('it cannot update lifecycle hook to have no lifecycle checks', async (t) =>
 
   const asset = await createAsset(umi, {
     owner,
+    plugins: [
+      {
+        type: 'LifecycleHook',
+        hookedProgram: account.publicKey,
+        lifecycleChecks: {
+          transfer: [CheckResult.CAN_LISTEN],
+        },
+      },
+    ],
   });
 
   await assertAsset(t, umi, {
@@ -86,8 +95,11 @@ test('it cannot update lifecycle hook to have no lifecycle checks', async (t) =>
   const result = updatePlugin(umi, {
     asset: asset.publicKey,
     plugin: {
+      key: {
+        type: 'LifecycleHook',
+        hookedProgram: account.publicKey,
+      },
       type: 'LifecycleHook',
-      hookedProgram: account.publicKey,
       lifecycleChecks: {},
     },
   }).sendAndConfirm(umi);

--- a/clients/js/test/externalPlugins/lifecycleHook.test.ts
+++ b/clients/js/test/externalPlugins/lifecycleHook.test.ts
@@ -1,0 +1,102 @@
+import test from 'ava';
+
+import { mplCoreOracleExample } from '@metaplex-foundation/mpl-core-oracle-example';
+import { generateSigner } from '@metaplex-foundation/umi';
+import {
+  assertAsset,
+  createUmi as baseCreateUmi,
+  DEFAULT_ASSET,
+} from '../_setupRaw';
+import { createAsset } from '../_setupSdk';
+import { addPlugin, updatePlugin } from '../../src';
+
+const createUmi = async () =>
+  (await baseCreateUmi()).use(mplCoreOracleExample());
+
+test('it cannot create asset with lifecycle hook that has no lifecycle checks', async (t) => {
+  const umi = await createUmi();
+  const account = generateSigner(umi);
+  const owner = generateSigner(umi);
+
+  // Lifecycle hook with no lifecycle checks
+  const result = createAsset(umi, {
+    owner,
+    plugins: [
+      {
+        type: 'LifecycleHook',
+        hookedProgram: account.publicKey,
+        lifecycleChecks: {},
+      },
+    ],
+  });
+
+  await t.throwsAsync(result, { name: 'RequiresLifecycleCheck' });
+});
+
+test('it cannot add lifecycle hook with no lifecycle checks to asset', async (t) => {
+  const umi = await createUmi();
+  const account = generateSigner(umi);
+  const owner = generateSigner(umi);
+
+  const asset = await createAsset(umi, {
+    owner,
+  });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: owner.publicKey,
+  });
+
+  // Oracle with no lifecycle checks
+  const result = addPlugin(umi, {
+    asset: asset.publicKey,
+    plugin: {
+      type: 'LifecycleHook',
+      hookedProgram: account.publicKey,
+      lifecycleChecks: {},
+    },
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'RequiresLifecycleCheck' });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: owner.publicKey,
+  });
+});
+
+test('it cannot update lifecycle hook to have no lifecycle checks', async (t) => {
+  const umi = await createUmi();
+  const account = generateSigner(umi);
+  const owner = generateSigner(umi);
+
+  const asset = await createAsset(umi, {
+    owner,
+  });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: owner.publicKey,
+  });
+
+  // Oracle with no lifecycle checks
+  const result = updatePlugin(umi, {
+    asset: asset.publicKey,
+    plugin: {
+      type: 'LifecycleHook',
+      hookedProgram: account.publicKey,
+      lifecycleChecks: {},
+    },
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'RequiresLifecycleCheck' });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: owner.publicKey,
+  });
+});

--- a/clients/js/test/externalPlugins/oracle.test.ts
+++ b/clients/js/test/externalPlugins/oracle.test.ts
@@ -40,6 +40,7 @@ import {
   transfer,
   update,
   addPlugin,
+  updatePlugin,
 } from '../../src';
 
 const createUmi = async () =>
@@ -303,6 +304,44 @@ test('it cannot add oracle with no lifecycle checks to asset', async (t) => {
   // Oracle with no lifecycle checks
   const result = addPlugin(umi, {
     asset: asset.publicKey,
+    plugin: {
+      type: 'Oracle',
+      resultsOffset: {
+        type: 'Anchor',
+      },
+      lifecycleChecks: {},
+      baseAddress: account.publicKey,
+    },
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'RequiresLifecycleCheck' });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: owner.publicKey,
+  });
+});
+
+test('it cannot update oracle to have no lifecycle checks', async (t) => {
+  const umi = await createUmi();
+  const account = generateSigner(umi);
+  const owner = generateSigner(umi);
+
+  const asset = await createAsset(umi, {
+    owner,
+  });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: owner.publicKey,
+  });
+
+  // Oracle with no lifecycle checks
+  const result = updatePlugin(umi, {
+    asset: asset.publicKey,
+
     plugin: {
       type: 'Oracle',
       resultsOffset: {

--- a/clients/js/test/externalPlugins/oracle.test.ts
+++ b/clients/js/test/externalPlugins/oracle.test.ts
@@ -330,6 +330,18 @@ test('it cannot update oracle to have no lifecycle checks', async (t) => {
 
   const asset = await createAsset(umi, {
     owner,
+    plugins: [
+      {
+        type: 'Oracle',
+        resultsOffset: {
+          type: 'Anchor',
+        },
+        lifecycleChecks: {
+          transfer: [CheckResult.CAN_REJECT],
+        },
+        baseAddress: account.publicKey,
+      },
+    ],
   });
 
   await assertAsset(t, umi, {
@@ -343,12 +355,15 @@ test('it cannot update oracle to have no lifecycle checks', async (t) => {
     asset: asset.publicKey,
 
     plugin: {
+      key: {
+        type: 'Oracle',
+        baseAddress: account.publicKey,
+      },
       type: 'Oracle',
       resultsOffset: {
         type: 'Anchor',
       },
       lifecycleChecks: {},
-      baseAddress: account.publicKey,
     },
   }).sendAndConfirm(umi);
 

--- a/clients/rust/src/generated/types/lifecycle_hook_init_info.rs
+++ b/clients/rust/src/generated/types/lifecycle_hook_init_info.rs
@@ -23,7 +23,7 @@ pub struct LifecycleHookInitInfo {
     )]
     pub hooked_program: Pubkey,
     pub init_plugin_authority: Option<PluginAuthority>,
-    pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
+    pub lifecycle_checks: Vec<(HookableLifecycleEvent, ExternalCheckResult)>,
     pub extra_accounts: Option<Vec<ExtraAccount>>,
     pub data_authority: Option<PluginAuthority>,
     pub schema: Option<ExternalPluginSchema>,

--- a/clients/rust/tests/add_external_plugins.rs
+++ b/clients/rust/tests/add_external_plugins.rs
@@ -62,10 +62,10 @@ async fn test_add_lifecycle_hook() {
             LifecycleHookInitInfo {
                 hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
                 init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
-                lifecycle_checks: Some(vec![(
+                lifecycle_checks: vec![(
                     HookableLifecycleEvent::Transfer,
                     ExternalCheckResult { flags: 1 },
-                )]),
+                )],
                 extra_accounts: None,
                 data_authority: Some(PluginAuthority::UpdateAuthority),
                 schema: None,
@@ -149,7 +149,7 @@ async fn test_cannot_add_lifecycle_hook_with_duplicate_lifecycle_checks() {
             LifecycleHookInitInfo {
                 hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
                 init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
-                lifecycle_checks: Some(vec![
+                lifecycle_checks: vec![
                     (
                         HookableLifecycleEvent::Transfer,
                         ExternalCheckResult { flags: 1 },
@@ -158,7 +158,7 @@ async fn test_cannot_add_lifecycle_hook_with_duplicate_lifecycle_checks() {
                         HookableLifecycleEvent::Transfer,
                         ExternalCheckResult { flags: 1 },
                     ),
-                ]),
+                ],
                 extra_accounts: None,
                 data_authority: Some(PluginAuthority::UpdateAuthority),
                 schema: None,

--- a/clients/rust/tests/create_with_external_plugins.rs
+++ b/clients/rust/tests/create_with_external_plugins.rs
@@ -36,10 +36,10 @@ async fn test_create_lifecycle_hook() {
                 LifecycleHookInitInfo {
                     hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
                     init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
-                    lifecycle_checks: Some(vec![(
+                    lifecycle_checks: vec![(
                         HookableLifecycleEvent::Transfer,
                         ExternalCheckResult { flags: 1 },
-                    )]),
+                    )],
                     extra_accounts: None,
                     data_authority: Some(PluginAuthority::UpdateAuthority),
                     schema: None,
@@ -94,7 +94,7 @@ async fn test_cannot_create_lifecycle_hook_with_duplicate_lifecycle_checks() {
                 LifecycleHookInitInfo {
                     hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
                     init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
-                    lifecycle_checks: Some(vec![
+                    lifecycle_checks: vec![
                         (
                             HookableLifecycleEvent::Transfer,
                             ExternalCheckResult { flags: 1 },
@@ -103,7 +103,7 @@ async fn test_cannot_create_lifecycle_hook_with_duplicate_lifecycle_checks() {
                             HookableLifecycleEvent::Transfer,
                             ExternalCheckResult { flags: 1 },
                         ),
-                    ]),
+                    ],
                     extra_accounts: None,
                     data_authority: Some(PluginAuthority::UpdateAuthority),
                     schema: None,

--- a/clients/rust/tests/remove_external_plugins.rs
+++ b/clients/rust/tests/remove_external_plugins.rs
@@ -37,10 +37,10 @@ async fn test_remove_lifecycle_hook() {
                 LifecycleHookInitInfo {
                     hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
                     init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
-                    lifecycle_checks: Some(vec![(
+                    lifecycle_checks: vec![(
                         HookableLifecycleEvent::Transfer,
                         ExternalCheckResult { flags: 1 },
-                    )]),
+                    )],
                     extra_accounts: None,
                     data_authority: Some(PluginAuthority::UpdateAuthority),
                     schema: None,

--- a/clients/rust/tests/update_external_plugins.rs
+++ b/clients/rust/tests/update_external_plugins.rs
@@ -38,10 +38,10 @@ async fn test_update_lifecycle_hook() {
                 LifecycleHookInitInfo {
                     hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
                     init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
-                    lifecycle_checks: Some(vec![(
+                    lifecycle_checks: vec![(
                         HookableLifecycleEvent::Transfer,
                         ExternalCheckResult { flags: 1 },
-                    )]),
+                    )],
                     extra_accounts: None,
                     data_authority: Some(PluginAuthority::UpdateAuthority),
                     schema: None,

--- a/clients/rust/tests/update_external_plugins.rs
+++ b/clients/rust/tests/update_external_plugins.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "test-sbf")]
 pub mod setup;
 use mpl_core::{
+    errors::MplCoreError,
     instructions::UpdateExternalPluginV1Builder,
     types::{
         DataStore, DataStoreInitInfo, DataStoreUpdateInfo, ExternalCheckResult, ExternalPlugin,
@@ -118,6 +119,105 @@ async fn test_update_lifecycle_hook() {
 }
 
 #[tokio::test]
+async fn test_cannot_update_lifecycle_hook_to_have_duplicate_lifecycle_checks() {
+    let mut context = program_test().start_with_context().await;
+
+    let asset = Keypair::new();
+    create_asset(
+        &mut context,
+        CreateAssetHelperArgs {
+            owner: None,
+            payer: None,
+            asset: &asset,
+            data_state: None,
+            name: None,
+            uri: None,
+            authority: None,
+            update_authority: None,
+            collection: None,
+            plugins: vec![],
+            external_plugins: vec![ExternalPluginInitInfo::LifecycleHook(
+                LifecycleHookInitInfo {
+                    hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+                    init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
+                    lifecycle_checks: vec![(
+                        HookableLifecycleEvent::Transfer,
+                        ExternalCheckResult { flags: 1 },
+                    )],
+                    extra_accounts: None,
+                    data_authority: Some(PluginAuthority::UpdateAuthority),
+                    schema: None,
+                },
+            )],
+        },
+    )
+    .await
+    .unwrap();
+
+    let owner = context.payer.pubkey();
+    let update_authority = context.payer.pubkey();
+    assert_asset(
+        &mut context,
+        AssertAssetHelperArgs {
+            asset: asset.pubkey(),
+            owner,
+            update_authority: Some(UpdateAuthority::Address(update_authority)),
+            name: None,
+            uri: None,
+            plugins: vec![],
+            external_plugins: vec![ExternalPlugin::LifecycleHook(LifecycleHook {
+                hooked_program: pubkey!("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+                extra_accounts: None,
+                data_authority: Some(PluginAuthority::UpdateAuthority),
+                schema: ExternalPluginSchema::Binary,
+            })],
+        },
+    )
+    .await;
+
+    let ix = UpdateExternalPluginV1Builder::new()
+        .asset(asset.pubkey())
+        .payer(context.payer.pubkey())
+        .key(ExternalPluginKey::LifecycleHook(pubkey!(
+            "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        )))
+        .update_info(ExternalPluginUpdateInfo::LifecycleHook(
+            LifecycleHookUpdateInfo {
+                lifecycle_checks: Some(vec![
+                    (
+                        HookableLifecycleEvent::Transfer,
+                        ExternalCheckResult { flags: 1 },
+                    ),
+                    (
+                        HookableLifecycleEvent::Transfer,
+                        ExternalCheckResult { flags: 1 },
+                    ),
+                ]),
+                extra_accounts: None,
+                schema: Some(ExternalPluginSchema::Json),
+            },
+        ))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    assert_custom_instruction_error!(0, error, MplCoreError::DuplicateLifecycleChecks);
+
+    // TODO: Check that registry record did not get updated.
+}
+
+#[tokio::test]
 async fn test_update_oracle() {
     let mut context = program_test().start_with_context().await;
 
@@ -207,6 +307,97 @@ async fn test_update_oracle() {
         },
     )
     .await;
+}
+
+#[tokio::test]
+async fn test_cannot_update_oracle_to_have_duplicate_lifecycle_checks() {
+    let mut context = program_test().start_with_context().await;
+
+    let asset = Keypair::new();
+    create_asset(
+        &mut context,
+        CreateAssetHelperArgs {
+            owner: None,
+            payer: None,
+            asset: &asset,
+            data_state: None,
+            name: None,
+            uri: None,
+            authority: None,
+            update_authority: None,
+            collection: None,
+            plugins: vec![],
+            external_plugins: vec![ExternalPluginInitInfo::Oracle(OracleInitInfo {
+                base_address: Pubkey::default(),
+                init_plugin_authority: Some(PluginAuthority::UpdateAuthority),
+                lifecycle_checks: vec![(
+                    HookableLifecycleEvent::Transfer,
+                    ExternalCheckResult { flags: 4 },
+                )],
+                pda: None,
+                results_offset: None,
+            })],
+        },
+    )
+    .await
+    .unwrap();
+
+    let owner = context.payer.pubkey();
+    let update_authority = context.payer.pubkey();
+    assert_asset(
+        &mut context,
+        AssertAssetHelperArgs {
+            asset: asset.pubkey(),
+            owner,
+            update_authority: Some(UpdateAuthority::Address(update_authority)),
+            name: None,
+            uri: None,
+            plugins: vec![],
+            external_plugins: vec![ExternalPlugin::Oracle(Oracle {
+                base_address: Pubkey::default(),
+                pda: None,
+                results_offset: ValidationResultsOffset::NoOffset,
+            })],
+        },
+    )
+    .await;
+
+    let ix = UpdateExternalPluginV1Builder::new()
+        .asset(asset.pubkey())
+        .payer(context.payer.pubkey())
+        .key(ExternalPluginKey::Oracle(Pubkey::default()))
+        .update_info(ExternalPluginUpdateInfo::Oracle(OracleUpdateInfo {
+            lifecycle_checks: Some(vec![
+                (
+                    HookableLifecycleEvent::Transfer,
+                    ExternalCheckResult { flags: 4 },
+                ),
+                (
+                    HookableLifecycleEvent::Transfer,
+                    ExternalCheckResult { flags: 4 },
+                ),
+            ]),
+            pda: None,
+            results_offset: Some(ValidationResultsOffset::Custom(10)),
+        }))
+        .instruction();
+
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let error = context
+        .banks_client
+        .process_transaction(tx)
+        .await
+        .unwrap_err();
+
+    assert_custom_instruction_error!(0, error, MplCoreError::DuplicateLifecycleChecks);
+
+    // TODO: Check that registry record did not get updated.
 }
 
 #[tokio::test]

--- a/idls/mpl_core.json
+++ b/idls/mpl_core.json
@@ -2278,17 +2278,15 @@
           {
             "name": "lifecycleChecks",
             "type": {
-              "option": {
-                "vec": {
-                  "tuple": [
-                    {
-                      "defined": "HookableLifecycleEvent"
-                    },
-                    {
-                      "defined": "ExternalCheckResult"
-                    }
-                  ]
-                }
+              "vec": {
+                "tuple": [
+                  {
+                    "defined": "HookableLifecycleEvent"
+                  },
+                  {
+                    "defined": "ExternalCheckResult"
+                  }
+                ]
               }
             }
           },

--- a/programs/mpl-core/src/plugins/external_plugins.rs
+++ b/programs/mpl-core/src/plugins/external_plugins.rs
@@ -94,21 +94,18 @@ impl ExternalPlugin {
     pub fn check_create(plugin: &ExternalPluginInitInfo) -> ExternalCheckResult {
         match plugin {
             ExternalPluginInitInfo::LifecycleHook(init_info) => {
-                if let Some(lifecycle_checks) = &init_info.lifecycle_checks {
-                    if let Some(checks) = lifecycle_checks
-                        .iter()
-                        .find(|event| event.0 == HookableLifecycleEvent::Create)
-                    {
-                        checks.1
-                    } else {
-                        ExternalCheckResult::none()
-                    }
+                if let Some(checks) = init_info
+                    .lifecycle_checks
+                    .iter()
+                    .find(|event| event.0 == HookableLifecycleEvent::Create)
+                {
+                    checks.1
                 } else {
                     ExternalCheckResult::none()
                 }
             }
             ExternalPluginInitInfo::Oracle(init_info) => {
-                if let Some(checks) = &init_info
+                if let Some(checks) = init_info
                     .lifecycle_checks
                     .iter()
                     .find(|event| event.0 == HookableLifecycleEvent::Create)

--- a/programs/mpl-core/src/plugins/lifecycle_hook.rs
+++ b/programs/mpl-core/src/plugins/lifecycle_hook.rs
@@ -73,7 +73,7 @@ pub struct LifecycleHookInitInfo {
     /// Initial plugin authority.
     pub init_plugin_authority: Option<Authority>,
     /// The lifecyle events for which the the external plugin is active.
-    pub lifecycle_checks: Option<Vec<(HookableLifecycleEvent, ExternalCheckResult)>>,
+    pub lifecycle_checks: Vec<(HookableLifecycleEvent, ExternalCheckResult)>,
     /// The extra accounts to use for the lifecycle hook.
     pub extra_accounts: Option<Vec<ExtraAccount>>,
     /// The authority of who can update the Lifecycle Hook data. This can be for the purposes

--- a/programs/mpl-core/src/processor/update_external_plugin.rs
+++ b/programs/mpl-core/src/processor/update_external_plugin.rs
@@ -82,7 +82,7 @@ pub(crate) fn update_external_plugin<'a>(
     let plugin_registry_clone = plugin_registry.clone();
     let (_, record) = find_external_plugin(&plugin_registry_clone, &args.key, ctx.accounts.asset)?;
     let mut registry_record = record.ok_or(MplCoreError::PluginNotFound)?.clone();
-    registry_record.update(&args.update_info);
+    registry_record.update(&args.update_info)?;
 
     let mut new_plugin = plugin.clone();
     new_plugin.update(&args.update_info);
@@ -219,7 +219,7 @@ pub(crate) fn update_collection_external_plugin<'a>(
     let (_, record) =
         find_external_plugin(&plugin_registry_clone, &args.key, ctx.accounts.collection)?;
     let mut registry_record = record.ok_or(MplCoreError::PluginNotFound)?.clone();
-    registry_record.update(&args.update_info);
+    registry_record.update(&args.update_info)?;
 
     let mut new_plugin = plugin.clone();
     new_plugin.update(&args.update_info);


### PR DESCRIPTION
### Notes
* Require `LifecycleHook` to have lifecycle checks.
* Modify `OracleInitInfo` to take a `Vec` instead of an `Option<Vec>` for lifecycle checks.
* Do not update lifecycle checks in the `RegistryRecord` when update value is `None`.
  * _Note the only reason lifecycle_checks is a an `Option` on the `RegistryRecord` is because it needs to work with `DataStore`._