### PR TITLE
Combine plugin updating into single utility function

### DIFF
--- a/clients/js/src/instructions/addPlugin.ts
+++ b/clients/js/src/instructions/addPlugin.ts
@@ -8,11 +8,15 @@ import {
   pluginAuthorityPairV2,
 } from '../plugins';
 
+export type AddPluginArgsPlugin =
+  | AddablePluginAuthorityPairArgsV2
+  | ExternalPluginInitInfoArgs;
+
 export type AddPluginArgs = Omit<
   Parameters<typeof addPluginV1>[1],
   'plugin'
 > & {
-  plugin: AddablePluginAuthorityPairArgsV2 | ExternalPluginInitInfoArgs;
+  plugin: AddPluginArgsPlugin;
 };
 
 export const addPlugin = (

--- a/clients/js/src/instructions/approvePluginAuthority.ts
+++ b/clients/js/src/instructions/approvePluginAuthority.ts
@@ -1,39 +1,25 @@
 import { Context } from '@metaplex-foundation/umi';
 import { approvePluginAuthorityV1, PluginType } from '../generated';
-import {
-  isExternalPluginType,
-  PluginAuthority,
-  pluginAuthorityToBase,
-} from '../plugins';
-import { ExternalPluginKey } from '../plugins/externalPluginKey';
+import { PluginAuthority, pluginAuthorityToBase } from '../plugins';
+
+export type ApprovePluginAuthorityArgsPlugin = {
+  type: keyof typeof PluginType;
+};
 
 export type ApprovePluginAuthorityArgs = Omit<
   Parameters<typeof approvePluginAuthorityV1>[1],
   'pluginType' | 'newAuthority'
 > & {
-  plugin:
-    | {
-        type: keyof typeof PluginType;
-      }
-    | ExternalPluginKey;
+  plugin: ApprovePluginAuthorityArgsPlugin;
   newAuthority: PluginAuthority;
 };
 
 export const approvePluginAuthority = (
   context: Pick<Context, 'payer' | 'programs' | 'identity'>,
   { plugin, newAuthority, ...args }: ApprovePluginAuthorityArgs
-) => {
-  if (isExternalPluginType(plugin)) {
-    // TODO implement this
-    // return approveExternalPluginAuthorityV1(context, {
-    //   ...args,
-    //   key: externalPluginKeyToBase(plugin as ExternalPluginKey),
-    // });
-  }
-
-  return approvePluginAuthorityV1(context, {
+) =>
+  approvePluginAuthorityV1(context, {
     ...args,
     pluginType: PluginType[plugin.type as keyof typeof PluginType],
     newAuthority: pluginAuthorityToBase(newAuthority),
   });
-};

--- a/clients/js/src/instructions/burn.ts
+++ b/clients/js/src/instructions/burn.ts
@@ -7,8 +7,8 @@ export type BurnArgs = Omit<
   Parameters<typeof burnV1>[1],
   'asset' | 'collection'
 > & {
-  asset: AssetV1;
-  collection?: CollectionV1;
+  asset: Pick<AssetV1, 'publicKey' | 'owner' | 'oracles' | 'lifecycleHooks'>;
+  collection?: Pick<CollectionV1, 'publicKey' | 'oracles' | 'lifecycleHooks'>;
 };
 
 export const burn = (

--- a/clients/js/src/instructions/create.ts
+++ b/clients/js/src/instructions/create.ts
@@ -3,7 +3,7 @@ import { CollectionV1, createV2, ExternalPluginSchema } from '../generated';
 import {
   createExternalPluginInitInfo,
   findExtraAccounts,
-  PluginArgsV2,
+  PluginAuthorityPairArgsV2,
   pluginAuthorityPairV2,
 } from '../plugins';
 import { deriveExternalPlugins } from '../helpers';
@@ -13,12 +13,16 @@ import {
   isExternalPluginType,
 } from '../plugins/externalPlugins';
 
+export type CreateArgsPlugin =
+  | PluginAuthorityPairArgsV2
+  | ExternalPluginInitInfoArgs;
+
 export type CreateArgs = Omit<
   Parameters<typeof createV2>[1],
   'plugins' | 'externalPlugins' | 'collection'
 > & {
-  collection?: CollectionV1;
-  plugins?: (PluginArgsV2 | ExternalPluginInitInfoArgs)[];
+  collection?: Pick<CollectionV1, 'publicKey' | 'oracles' | 'lifecycleHooks'>;
+  plugins?: CreateArgsPlugin[];
 };
 
 export const create = (
@@ -33,7 +37,7 @@ export const create = (
   };
 
   const externalPlugins: ExternalPluginInitInfoArgs[] = [];
-  const firstPartyPlugins: PluginArgsV2[] = [];
+  const firstPartyPlugins: PluginAuthorityPairArgsV2[] = [];
 
   // Create dummy external plugins to resuse findExtraAccounts method
   plugins?.forEach((plugin) => {
@@ -69,7 +73,7 @@ export const create = (
         // Do nothing
       }
     } else {
-      firstPartyPlugins.push(plugin as PluginArgsV2);
+      firstPartyPlugins.push(plugin as PluginAuthorityPairArgsV2);
     }
   });
 

--- a/clients/js/src/instructions/removePlugin.ts
+++ b/clients/js/src/instructions/removePlugin.ts
@@ -10,15 +10,17 @@ import {
   externalPluginKeyToBase,
 } from '../plugins/externalPluginKey';
 
+export type RemovePluginArgsPlugin =
+  | {
+      type: Exclude<keyof typeof PluginType, 'Edition'>;
+    }
+  | ExternalPluginKey;
+
 export type RemovePluginArgs = Omit<
   Parameters<typeof removePluginV1>[1],
   'pluginType'
 > & {
-  plugin:
-    | {
-        type: Exclude<keyof typeof PluginType, 'Edition'>;
-      }
-    | ExternalPluginKey;
+  plugin: RemovePluginArgsPlugin;
 };
 
 export const removePlugin = (

--- a/clients/js/src/instructions/revokePluginAuthority.ts
+++ b/clients/js/src/instructions/revokePluginAuthority.ts
@@ -1,33 +1,22 @@
 import { Context } from '@metaplex-foundation/umi';
 import { revokePluginAuthorityV1, PluginType } from '../generated';
-import { isExternalPluginType } from '../plugins';
-import { ExternalPluginKey } from '../plugins/externalPluginKey';
+
+export type RevokePluginAuthorityArgsPlugin = {
+  type: keyof typeof PluginType;
+};
 
 export type RevokePluginAuthorityArgs = Omit<
   Parameters<typeof revokePluginAuthorityV1>[1],
   'pluginType'
 > & {
-  plugin:
-    | {
-        type: keyof typeof PluginType;
-      }
-    | ExternalPluginKey;
+  plugin: RevokePluginAuthorityArgsPlugin;
 };
 
 export const revokePluginAuthority = (
   context: Pick<Context, 'payer' | 'programs' | 'identity'>,
   { plugin, ...args }: RevokePluginAuthorityArgs
-) => {
-  if (isExternalPluginType(plugin)) {
-    // TODO implement this
-    // return revokeExternalPluginAuthorityV1(context, {
-    //   ...args,
-    //   key: externalPluginKeyToBase(plugin as ExternalPluginKey),
-    // });
-  }
-
-  return revokePluginAuthorityV1(context, {
+) =>
+  revokePluginAuthorityV1(context, {
     ...args,
     pluginType: PluginType[plugin.type as keyof typeof PluginType],
   });
-};

--- a/clients/js/src/instructions/transfer.ts
+++ b/clients/js/src/instructions/transfer.ts
@@ -7,8 +7,8 @@ export type TransferArgs = Omit<
   Parameters<typeof transferV1>[1],
   'asset' | 'collection'
 > & {
-  asset: AssetV1;
-  collection?: CollectionV1;
+  asset: Pick<AssetV1, 'publicKey' | 'owner' | 'oracles' | 'lifecycleHooks'>;
+  collection?: Pick<CollectionV1, 'publicKey' | 'oracles' | 'lifecycleHooks'>;
 };
 
 export const transfer = (

--- a/clients/js/src/instructions/update.ts
+++ b/clients/js/src/instructions/update.ts
@@ -12,8 +12,8 @@ export type UpdateArgs = Omit<
   Parameters<typeof updateV1>[1],
   'asset' | 'collection' | 'newName' | 'newUri'
 > & {
-  asset: AssetV1;
-  collection?: CollectionV1;
+  asset: Pick<AssetV1, 'publicKey' | 'owner' | 'oracles' | 'lifecycleHooks'>;
+  collection?: Pick<CollectionV1, 'publicKey' | 'oracles' | 'lifecycleHooks'>;
   name?: UpdateV1InstructionDataArgs['newName'];
   uri?: UpdateV1InstructionDataArgs['newUri'];
 };

--- a/clients/js/src/instructions/updatePlugin.ts
+++ b/clients/js/src/instructions/updatePlugin.ts
@@ -9,11 +9,15 @@ import {
 } from '../plugins';
 import { ExternalPluginUpdateInfoArgs } from '../plugins/externalPlugins';
 
+export type UpdatePluginArgsPlugin =
+  | PluginArgsV2
+  | ExternalPluginUpdateInfoArgs;
+
 export type UpdatePluginArgs = Omit<
   Parameters<typeof updatePluginV1>[1],
   'plugin'
 > & {
-  plugin: PluginArgsV2 | ExternalPluginUpdateInfoArgs;
+  plugin: UpdatePluginArgsPlugin;
 };
 
 export const updatePlugin = (

--- a/programs/mpl-core/src/plugins/external_plugins.rs
+++ b/programs/mpl-core/src/plugins/external_plugins.rs
@@ -1,13 +1,10 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
-    pubkey::Pubkey,
-};
+use solana_program::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
 use strum::EnumCount;
 
 use crate::{
     error::MplCoreError,
-    state::{AssetV1, SolanaAccount},
+    state::{AssetV1, PluginSolanaAccount, SolanaAccount},
 };
 
 use super::{
@@ -180,24 +177,9 @@ impl ExternalPlugin {
             ExternalPlugin::DataStore(data_store) => data_store.validate_add_external_plugin(ctx),
         }
     }
-
-    /// Load and deserialize a plugin from an offset in the account.
-    pub fn load(account: &AccountInfo, offset: usize) -> Result<Self, ProgramError> {
-        let mut bytes: &[u8] = &(*account.data).borrow()[offset..];
-        Self::deserialize(&mut bytes).map_err(|error| {
-            msg!("Error: {}", error);
-            MplCoreError::DeserializationError.into()
-        })
-    }
-
-    /// Save and serialize a plugin to an offset in the account.
-    pub fn save(&self, account: &AccountInfo, offset: usize) -> ProgramResult {
-        borsh::to_writer(&mut account.data.borrow_mut()[offset..], self).map_err(|error| {
-            msg!("Error: {}", error);
-            MplCoreError::SerializationError.into()
-        })
-    }
 }
+
+impl PluginSolanaAccount for ExternalPlugin {}
 
 impl From<&ExternalPluginInitInfo> for ExternalPlugin {
     fn from(init_info: &ExternalPluginInitInfo) -> Self {

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use crate::{
     error::MplCoreError,
-    state::{Authority, Key},
+    state::{Authority, Key, PluginSolanaAccount},
 };
 
 use super::{

--- a/programs/mpl-core/src/plugins/mod.rs
+++ b/programs/mpl-core/src/plugins/mod.rs
@@ -43,15 +43,9 @@ pub use utils::*;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::ToPrimitive;
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_error::ProgramError,
-};
 use strum::EnumCount;
 
-use crate::{
-    error::MplCoreError,
-    state::{Authority, Compressible, DataBlob},
-};
+use crate::state::{Authority, Compressible, DataBlob, PluginSolanaAccount};
 
 /// Definition of the plugin variants, each containing a link to the plugin struct.
 #[repr(C)]
@@ -86,24 +80,9 @@ impl Plugin {
     pub fn manager(&self) -> Authority {
         PluginType::from(self).manager()
     }
-
-    /// Load and deserialize a plugin from an offset in the account.
-    pub fn load(account: &AccountInfo, offset: usize) -> Result<Self, ProgramError> {
-        let mut bytes: &[u8] = &(*account.data).borrow()[offset..];
-        Self::deserialize(&mut bytes).map_err(|error| {
-            msg!("Error: {}", error);
-            MplCoreError::DeserializationError.into()
-        })
-    }
-
-    /// Save and serialize a plugin to an offset in the account.
-    pub fn save(&self, account: &AccountInfo, offset: usize) -> ProgramResult {
-        borsh::to_writer(&mut account.data.borrow_mut()[offset..], self).map_err(|error| {
-            msg!("Error: {}", error);
-            MplCoreError::SerializationError.into()
-        })
-    }
 }
+
+impl PluginSolanaAccount for Plugin {}
 
 impl Compressible for Plugin {}
 

--- a/programs/mpl-core/src/plugins/utils.rs
+++ b/programs/mpl-core/src/plugins/utils.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use crate::{
     error::MplCoreError,
     plugins::{ExternalCheckResult, HookableLifecycleEvent},
-    state::{AssetV1, Authority, CoreAsset, DataBlob, Key, SolanaAccount},
+    state::{AssetV1, Authority, CoreAsset, DataBlob, Key, PluginSolanaAccount, SolanaAccount},
     utils::resize_or_reallocate_account,
 };
 

--- a/programs/mpl-core/src/processor/update_external_plugin.rs
+++ b/programs/mpl-core/src/processor/update_external_plugin.rs
@@ -10,8 +10,8 @@ use crate::{
         UpdateCollectionExternalPluginV1Accounts, UpdateExternalPluginV1Accounts,
     },
     plugins::{
-        fetch_wrapped_external_plugin, find_external_plugin, ExternalPluginKey,
-        ExternalPluginUpdateInfo, Plugin, PluginType,
+        fetch_wrapped_external_plugin, find_external_plugin, ExternalPlugin, ExternalPluginKey,
+        ExternalPluginUpdateInfo, Plugin, PluginHeaderV1, PluginRegistryV1, PluginType,
     },
     state::{AssetV1, CollectionV1, DataBlob, Key, SolanaAccount},
     utils::{
@@ -76,92 +76,20 @@ pub(crate) fn update_external_plugin<'a>(
         None,
     )?;
 
-    let mut plugin_registry = plugin_registry.ok_or(MplCoreError::PluginsNotInitialized)?;
-    let mut plugin_header = plugin_header.ok_or(MplCoreError::PluginsNotInitialized)?;
-
-    let plugin_registry_clone = plugin_registry.clone();
-    let (_, record) = find_external_plugin(&plugin_registry_clone, &args.key, ctx.accounts.asset)?;
-    let mut registry_record = record.ok_or(MplCoreError::PluginNotFound)?.clone();
-    registry_record.update(&args.update_info)?;
-
-    let mut new_plugin = plugin.clone();
-    new_plugin.update(&args.update_info);
-
-    let plugin_data = plugin.try_to_vec()?;
-    let new_plugin_data = new_plugin.try_to_vec()?;
-
-    // The difference in size between the new and old account which is used to calculate the new size of the account.
-    let plugin_size = plugin_data.len() as isize;
-    let size_diff = (new_plugin_data.len() as isize)
-        .checked_sub(plugin_size)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-
-    // The new size of the account.
-    let new_size = (ctx.accounts.asset.data_len() as isize)
-        .checked_add(size_diff)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-
-    // The new offset of the plugin registry is the old offset plus the size difference.
-    let registry_offset = plugin_header.plugin_registry_offset;
-    let new_registry_offset = (registry_offset as isize)
-        .checked_add(size_diff)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-    plugin_header.plugin_registry_offset = new_registry_offset as usize;
-
-    // The offset of the first plugin is the plugin offset plus the size of the plugin.
-    let next_plugin_offset = (registry_record.offset as isize)
-        .checked_add(plugin_size)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-
-    let new_next_plugin_offset = next_plugin_offset
-        .checked_add(size_diff)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-
-    // //TODO: This is memory intensive, we should use memmove instead probably.
-    let src =
-        ctx.accounts.asset.data.borrow()[(next_plugin_offset as usize)..registry_offset].to_vec();
-
-    resize_or_reallocate_account(
-        ctx.accounts.asset,
-        ctx.accounts.payer,
-        ctx.accounts.system_program,
-        new_size as usize,
-    )?;
-
-    sol_memcpy(
-        &mut ctx.accounts.asset.data.borrow_mut()[(new_next_plugin_offset as usize)..],
-        &src,
-        src.len(),
-    );
-
-    plugin_header.save(ctx.accounts.asset, asset.get_size())?;
-
-    // Move offsets for existing registry records.
-    for record in &mut plugin_registry.external_registry {
-        if registry_record.offset < record.offset {
-            record
-                .offset
-                .checked_add(size_diff as usize)
-                .ok_or(MplCoreError::NumericalOverflow)?;
-        }
-    }
-
-    for record in &mut plugin_registry.registry {
-        if registry_record.offset < record.offset {
-            record
-                .offset
-                .checked_add(size_diff as usize)
-                .ok_or(MplCoreError::NumericalOverflow)?;
-        }
-    }
-
-    plugin_registry.save(ctx.accounts.asset, new_registry_offset as usize)?;
-    new_plugin.save(ctx.accounts.asset, registry_record.offset)?;
-
     // Increment sequence number and save only if it is `Some(_)`.
     asset.increment_seq_and_save(ctx.accounts.asset)?;
 
-    process_update_external_plugin()
+    process_update_external_plugin(
+        asset,
+        plugin,
+        args.key,
+        args.update_info,
+        plugin_header,
+        plugin_registry,
+        ctx.accounts.asset,
+        ctx.accounts.payer,
+        ctx.accounts.system_program,
+    )
 }
 
 #[repr(C)]
@@ -212,17 +140,41 @@ pub(crate) fn update_collection_external_plugin<'a>(
         None,
     )?;
 
+    process_update_external_plugin(
+        collection,
+        plugin,
+        args.key,
+        args.update_info,
+        plugin_header,
+        plugin_registry,
+        ctx.accounts.collection,
+        ctx.accounts.payer,
+        ctx.accounts.system_program,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_update_external_plugin<'a, T: DataBlob + SolanaAccount>(
+    core: T,
+    plugin: ExternalPlugin,
+    key: ExternalPluginKey,
+    update_info: ExternalPluginUpdateInfo,
+    plugin_header: Option<PluginHeaderV1>,
+    plugin_registry: Option<PluginRegistryV1>,
+    account: &AccountInfo<'a>,
+    payer: &AccountInfo<'a>,
+    system_program: &AccountInfo<'a>,
+) -> ProgramResult {
     let mut plugin_registry = plugin_registry.ok_or(MplCoreError::PluginsNotInitialized)?;
     let mut plugin_header = plugin_header.ok_or(MplCoreError::PluginsNotInitialized)?;
 
     let plugin_registry_clone = plugin_registry.clone();
-    let (_, record) =
-        find_external_plugin(&plugin_registry_clone, &args.key, ctx.accounts.collection)?;
+    let (_, record) = find_external_plugin(&plugin_registry_clone, &key, account)?;
     let mut registry_record = record.ok_or(MplCoreError::PluginNotFound)?.clone();
-    registry_record.update(&args.update_info)?;
+    registry_record.update(&update_info)?;
 
     let mut new_plugin = plugin.clone();
-    new_plugin.update(&args.update_info);
+    new_plugin.update(&update_info);
 
     let plugin_data = plugin.try_to_vec()?;
     let new_plugin_data = new_plugin.try_to_vec()?;
@@ -234,7 +186,7 @@ pub(crate) fn update_collection_external_plugin<'a>(
         .ok_or(MplCoreError::NumericalOverflow)?;
 
     // The new size of the account.
-    let new_size = (ctx.accounts.collection.data_len() as isize)
+    let new_size = (account.data_len() as isize)
         .checked_add(size_diff)
         .ok_or(MplCoreError::NumericalOverflow)?;
 
@@ -255,23 +207,17 @@ pub(crate) fn update_collection_external_plugin<'a>(
         .ok_or(MplCoreError::NumericalOverflow)?;
 
     // //TODO: This is memory intensive, we should use memmove instead probably.
-    let src = ctx.accounts.collection.data.borrow()[(next_plugin_offset as usize)..registry_offset]
-        .to_vec();
+    let src = account.data.borrow()[(next_plugin_offset as usize)..registry_offset].to_vec();
 
-    resize_or_reallocate_account(
-        ctx.accounts.collection,
-        ctx.accounts.payer,
-        ctx.accounts.system_program,
-        new_size as usize,
-    )?;
+    resize_or_reallocate_account(account, payer, system_program, new_size as usize)?;
 
     sol_memcpy(
-        &mut ctx.accounts.collection.data.borrow_mut()[(new_next_plugin_offset as usize)..],
+        &mut account.data.borrow_mut()[(new_next_plugin_offset as usize)..],
         &src,
         src.len(),
     );
 
-    plugin_header.save(ctx.accounts.collection, collection.get_size())?;
+    plugin_header.save(account, core.get_size())?;
 
     // Move offsets for existing registry records.
     for record in &mut plugin_registry.external_registry {
@@ -292,13 +238,8 @@ pub(crate) fn update_collection_external_plugin<'a>(
         }
     }
 
-    plugin_registry.save(ctx.accounts.collection, new_registry_offset as usize)?;
-    new_plugin.save(ctx.accounts.collection, registry_record.offset)?;
+    plugin_registry.save(account, new_registry_offset as usize)?;
+    new_plugin.save(account, registry_record.offset)?;
 
-    process_update_external_plugin()
-}
-
-//TODO
-fn process_update_external_plugin() -> ProgramResult {
     Ok(())
 }

--- a/programs/mpl-core/src/processor/update_external_plugin.rs
+++ b/programs/mpl-core/src/processor/update_external_plugin.rs
@@ -222,19 +222,21 @@ fn process_update_external_plugin<'a, T: DataBlob + SolanaAccount>(
     // Move offsets for existing registry records.
     for record in &mut plugin_registry.external_registry {
         if registry_record.offset < record.offset {
-            record
-                .offset
-                .checked_add(size_diff as usize)
+            let new_offset = (record.offset as isize)
+                .checked_add(size_diff)
                 .ok_or(MplCoreError::NumericalOverflow)?;
+
+            record.offset = new_offset as usize;
         }
     }
 
     for record in &mut plugin_registry.registry {
         if registry_record.offset < record.offset {
-            record
-                .offset
-                .checked_add(size_diff as usize)
+            let new_offset = (record.offset as isize)
+                .checked_add(size_diff)
                 .ok_or(MplCoreError::NumericalOverflow)?;
+
+            record.offset = new_offset as usize;
         }
     }
 

--- a/programs/mpl-core/src/processor/update_external_plugin.rs
+++ b/programs/mpl-core/src/processor/update_external_plugin.rs
@@ -1,8 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpl_utils::assert_signer;
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, msg, program_memory::sol_memcpy,
-};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg};
 
 use crate::{
     error::MplCoreError,
@@ -13,9 +11,9 @@ use crate::{
         fetch_wrapped_external_plugin, find_external_plugin, ExternalPlugin, ExternalPluginKey,
         ExternalPluginUpdateInfo, Plugin, PluginHeaderV1, PluginRegistryV1, PluginType,
     },
-    state::{AssetV1, CollectionV1, DataBlob, Key, SolanaAccount},
+    state::{AssetV1, CollectionV1, DataBlob, Key, PluginSolanaAccount, SolanaAccount},
     utils::{
-        load_key, resize_or_reallocate_account, resolve_authority, validate_asset_permissions,
+        load_key, move_plugins_and_registry, resolve_authority, validate_asset_permissions,
         validate_collection_permissions,
     },
 };
@@ -180,68 +178,26 @@ fn process_update_external_plugin<'a, T: DataBlob + SolanaAccount>(
     let new_plugin_data = new_plugin.try_to_vec()?;
 
     // The difference in size between the new and old account which is used to calculate the new size of the account.
-    let plugin_size = plugin_data.len() as isize;
+    let plugin_size = plugin_data.len();
     let size_diff = (new_plugin_data.len() as isize)
-        .checked_sub(plugin_size)
+        .checked_sub(plugin_size as isize)
         .ok_or(MplCoreError::NumericalOverflow)?;
 
-    // The new size of the account.
-    let new_size = (account.data_len() as isize)
-        .checked_add(size_diff)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-
-    // The new offset of the plugin registry is the old offset plus the size difference.
-    let registry_offset = plugin_header.plugin_registry_offset;
-    let new_registry_offset = (registry_offset as isize)
-        .checked_add(size_diff)
-        .ok_or(MplCoreError::NumericalOverflow)?;
-    plugin_header.plugin_registry_offset = new_registry_offset as usize;
-
-    // The offset of the first plugin is the plugin offset plus the size of the plugin.
-    let next_plugin_offset = (registry_record.offset as isize)
+    let data_to_move_location = (registry_record.offset)
         .checked_add(plugin_size)
         .ok_or(MplCoreError::NumericalOverflow)?;
 
-    let new_next_plugin_offset = next_plugin_offset
-        .checked_add(size_diff)
-        .ok_or(MplCoreError::NumericalOverflow)?;
+    move_plugins_and_registry(
+        core.get_size(),
+        size_diff,
+        registry_record.offset,
+        data_to_move_location,
+        &mut plugin_header,
+        &mut plugin_registry,
+        account,
+        payer,
+        system_program,
+    )?;
 
-    // //TODO: This is memory intensive, we should use memmove instead probably.
-    let src = account.data.borrow()[(next_plugin_offset as usize)..registry_offset].to_vec();
-
-    resize_or_reallocate_account(account, payer, system_program, new_size as usize)?;
-
-    sol_memcpy(
-        &mut account.data.borrow_mut()[(new_next_plugin_offset as usize)..],
-        &src,
-        src.len(),
-    );
-
-    plugin_header.save(account, core.get_size())?;
-
-    // Move offsets for existing registry records.
-    for record in &mut plugin_registry.external_registry {
-        if registry_record.offset < record.offset {
-            let new_offset = (record.offset as isize)
-                .checked_add(size_diff)
-                .ok_or(MplCoreError::NumericalOverflow)?;
-
-            record.offset = new_offset as usize;
-        }
-    }
-
-    for record in &mut plugin_registry.registry {
-        if registry_record.offset < record.offset {
-            let new_offset = (record.offset as isize)
-                .checked_add(size_diff)
-                .ok_or(MplCoreError::NumericalOverflow)?;
-
-            record.offset = new_offset as usize;
-        }
-    }
-
-    plugin_registry.save(account, new_registry_offset as usize)?;
-    new_plugin.save(account, registry_record.offset)?;
-
-    Ok(())
+    new_plugin.save(account, registry_record.offset)
 }

--- a/programs/mpl-core/src/state/traits.rs
+++ b/programs/mpl-core/src/state/traits.rs
@@ -44,6 +44,26 @@ pub trait SolanaAccount: BorshSerialize + BorshDeserialize {
     }
 }
 
+/// A trait for Solana accounts without a key.
+pub trait PluginSolanaAccount: BorshSerialize + BorshDeserialize {
+    /// Load and deserialize a plugin from an offset in the account.
+    fn load(account: &AccountInfo, offset: usize) -> Result<Self, ProgramError> {
+        let mut bytes: &[u8] = &(*account.data).borrow()[offset..];
+        Self::deserialize(&mut bytes).map_err(|error| {
+            msg!("Error: {}", error);
+            MplCoreError::DeserializationError.into()
+        })
+    }
+
+    /// Save and serialize a plugin to an offset in the account.
+    fn save(&self, account: &AccountInfo, offset: usize) -> ProgramResult {
+        borsh::to_writer(&mut account.data.borrow_mut()[offset..], self).map_err(|error| {
+            msg!("Error: {}", error);
+            MplCoreError::SerializationError.into()
+        })
+    }
+}
+
 /// A trait for data that can be compressed.
 pub trait Compressible: BorshSerialize + BorshDeserialize {
     /// Get the hash of the compressed data.


### PR DESCRIPTION
This combines the code that moves the plugins and registry in `update`, `update_plugin`, and `update_external_plugin` to use a single utility function called `move_plugins_and_registry`.  It is built upon https://github.com/metaplex-foundation/mpl-core/pull/112