### PR TITLE
Add external plugins handling to `IndexableAsset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
  "assert_matches",
  "base64 0.22.0",
  "borsh 0.10.3",
+ "modular-bitfield",
  "num-derive 0.3.3",
  "num-traits",
  "rmp-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,9 @@ dependencies = [
  "borsh 0.10.3",
  "num-derive 0.3.3",
  "num-traits",
+ "rmp-serde",
  "serde",
+ "serde_json",
  "serde_with 3.4.0",
  "solana-program",
  "solana-program-test",
@@ -3126,6 +3128,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3329,9 +3353,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
@@ -3347,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -19,7 +19,9 @@ anchor = ["dep:anchor-lang"]
 borsh = "^0.10"
 num-derive = "^0.3"
 num-traits = "^0.2"
+rmp-serde = "1.0"
 serde = { version = "^1.0", features = ["derive"], optional = true }
+serde_json = "1.0"
 serde_with = { version = "^3.0", optional = true }
 solana-program = "> 1.14, < 1.18"
 thiserror = "^1.0"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -27,6 +27,7 @@ solana-program = "> 1.14, < 1.18"
 thiserror = "^1.0"
 base64 = "0.22.0"
 anchor-lang = { version = "0.30.0", optional = true }
+modular-bitfield = "0.11.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/clients/rust/src/hooked/advanced_types.rs
+++ b/clients/rust/src/hooked/advanced_types.rs
@@ -214,7 +214,10 @@ pub struct ExternalRegistryRecordSafe {
 
 impl ExternalRegistryRecordSafe {
     /// Associated function for sorting `RegistryRecordIndexable` by offset.
-    pub fn compare_offsets(a: &RegistryRecordSafe, b: &RegistryRecordSafe) -> Ordering {
+    pub fn compare_offsets(
+        a: &ExternalRegistryRecordSafe,
+        b: &ExternalRegistryRecordSafe,
+    ) -> Ordering {
         a.offset.cmp(&b.offset)
     }
 }

--- a/clients/rust/src/indexable_asset.rs
+++ b/clients/rust/src/indexable_asset.rs
@@ -50,7 +50,7 @@ pub struct IndexableExternalPluginSchemaV1 {
     pub lifecycle_checks: Option<LifecycleChecks>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub unknown_lifecycle_checks: Option<Vec<(u8, ExternalCheckResult)>>,
-    pub external_plugin_adapter: ExternalPluginAdapter,
+    pub adapter_config: ExternalPluginAdapter,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub data_offset: Option<u64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -70,8 +70,8 @@ pub struct IndexableUnknownExternalPluginSchemaV1 {
     pub lifecycle_checks: Option<LifecycleChecks>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub unknown_lifecycle_checks: Option<Vec<(u8, ExternalCheckResult)>>,
-    pub unknown_external_plugin_adapter_type: u8,
-    pub unknown_external_plugin_adapter: String,
+    pub unknown_adapter_type: u8,
+    pub unknown_adapter_config: String,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub data_offset: Option<u64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -227,10 +227,10 @@ impl ProcessedExternalPlugin {
         let processed_plugin = if let Some(external_plugin_adapter_type) =
             ExternalPluginAdapterType::from_u8(external_plugin_adapter_type)
         {
-            let external_plugin_adapter = ExternalPluginAdapter::deserialize(plugin_slice)?;
+            let adapter_config = ExternalPluginAdapter::deserialize(plugin_slice)?;
             let (data_offset, data_len, data) = match external_plugin_data_info {
                 Some(data_info) => {
-                    let schema = match &external_plugin_adapter {
+                    let schema = match &adapter_config {
                         ExternalPluginAdapter::LifecycleHook(lifecycle_hook) => {
                             &lifecycle_hook.schema
                         }
@@ -253,7 +253,7 @@ impl ProcessedExternalPlugin {
                 authority,
                 lifecycle_checks: known_lifecycle_checks,
                 unknown_lifecycle_checks,
-                external_plugin_adapter,
+                adapter_config,
                 data_offset,
                 data_len,
                 data,
@@ -278,8 +278,8 @@ impl ProcessedExternalPlugin {
                 authority,
                 lifecycle_checks: known_lifecycle_checks,
                 unknown_lifecycle_checks,
-                unknown_external_plugin_adapter_type: external_plugin_adapter_type,
-                unknown_external_plugin_adapter: encoded,
+                unknown_adapter_type: external_plugin_adapter_type,
+                unknown_adapter_config: encoded,
                 data_offset,
                 data_len,
                 data,

--- a/clients/rust/src/indexable_asset.rs
+++ b/clients/rust/src/indexable_asset.rs
@@ -46,6 +46,7 @@ pub struct IndexableExternalPluginSchemaV1 {
     pub index: u64,
     pub offset: u64,
     pub authority: PluginAuthority,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub lifecycle_checks: Option<LifecycleChecks>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub unknown_lifecycle_checks: Option<Vec<(u8, ExternalCheckResult)>>,
@@ -65,6 +66,7 @@ pub struct IndexableUnknownExternalPluginSchemaV1 {
     pub index: u64,
     pub offset: u64,
     pub authority: PluginAuthority,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub lifecycle_checks: Option<LifecycleChecks>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub unknown_lifecycle_checks: Option<Vec<(u8, ExternalCheckResult)>>,


### PR DESCRIPTION
### Notes
* For most things that you don't always expect to be there, like `data`, `data_offset`, `data_len`, and `lifecycle_checks`, and `unknown_lifecycle_checks`, they are not printed if they are `None`.  This is also true at the Asset level with `unknown_plugins` and `unknown_external_plugins`.
* The exception to this is the `plugins` / `external_plugins` sections on the Asset, where an empty object is still printed if there are not any.  This seems right given that one would often care about the presence of plugins so seeing empty set is valuable.  This is how it has been for first party plugins, i.e. `"plugins": {}`.
* Known external plugins are serialized as an array, because there can be duplicate types.  This is in contrast to first party plugins which are serialized as a map because there can only be one of each type.
* Similar to the JS SDK V1, `lifecycle_checks` are transformed from bitflags into a struct with Vec of enum values for each `ExternalCheckResult`.

### Testing
* This is being tested by the following DAS PR: https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/194
* However, I need to release this Rust client in order to properly complete the DAS PR.
* Example output from Asset `4aarnaiMVtGEp5nToRqBEUGtqY2F1gW2V8bBQe1rN5V9` on devnet with two Oracle external plugins configured:
```
"external_plugins": [
  {
    "type": "Oracle",
    "index": 0,
    "offset": 119,
    "authority": {
      "type": "UpdateAuthority",
      "address": null
    },
    "adapter_config": {
      "base_address": "655aWrKDz4hNFGaSzxmT9xuwxTKPrvb5SMDohCfVFCXL",
      "results_offset": "Anchor",
      "base_address_config": null
    },
    "lifecycle_checks": {
      "update": [
        "CanReject"
      ]
    }
  },
  {
    "type": "Oracle",
    "index": 1,
    "offset": 154,
    "authority": {
      "type": "UpdateAuthority",
      "address": null
    },
    "adapter_config": {
      "base_address": "6CGzRzs53RppPfSimeEjEYhKMagP9rT9zZrEVVgjSq7A",
      "results_offset": "Anchor",
      "base_address_config": null
    },
    "lifecycle_checks": {
      "update": [
        "CanReject"
      ]
    }
  }
]
```