### PR TITLE
Add external plugin data to Asset and Collection in Rust client

### DIFF
--- a/clients/rust/src/hooked/advanced_types.rs
+++ b/clients/rust/src/hooked/advanced_types.rs
@@ -192,7 +192,6 @@ pub struct ExternalPluginAdaptersList {
 #[derive(Debug)]
 pub struct LifecycleHookWithData {
     pub base: LifecycleHook,
-    pub data_string: String,
     pub data_offset: usize,
     pub data_len: usize,
 }
@@ -200,7 +199,6 @@ pub struct LifecycleHookWithData {
 #[derive(Debug)]
 pub struct AppDataWithData {
     pub base: AppData,
-    pub data_string: String,
     pub data_offset: usize,
     pub data_len: usize,
 }
@@ -208,7 +206,6 @@ pub struct AppDataWithData {
 #[derive(Debug)]
 pub struct DataSectionWithData {
     pub base: DataSection,
-    pub data_string: String,
     pub data_offset: usize,
     pub data_len: usize,
 }

--- a/clients/rust/src/hooked/advanced_types.rs
+++ b/clients/rust/src/hooked/advanced_types.rs
@@ -181,12 +181,36 @@ pub struct PluginsList {
 
 #[derive(Debug, Default)]
 pub struct ExternalPluginAdaptersList {
-    pub lifecycle_hooks: Vec<LifecycleHook>,
+    pub lifecycle_hooks: Vec<LifecycleHookWithData>,
     pub linked_lifecycle_hooks: Vec<LinkedLifecycleHook>,
     pub oracles: Vec<Oracle>,
-    pub app_data: Vec<AppData>,
+    pub app_data: Vec<AppDataWithData>,
     pub linked_app_data: Vec<LinkedAppData>,
-    pub data_sections: Vec<DataSection>,
+    pub data_sections: Vec<DataSectionWithData>,
+}
+
+#[derive(Debug)]
+pub struct LifecycleHookWithData {
+    pub base: LifecycleHook,
+    pub data_string: String,
+    pub data_offset: usize,
+    pub data_len: usize,
+}
+
+#[derive(Debug)]
+pub struct AppDataWithData {
+    pub base: AppData,
+    pub data_string: String,
+    pub data_offset: usize,
+    pub data_len: usize,
+}
+
+#[derive(Debug)]
+pub struct DataSectionWithData {
+    pub base: DataSection,
+    pub data_string: String,
+    pub data_offset: usize,
+    pub data_len: usize,
 }
 
 #[derive(Debug)]

--- a/clients/rust/src/hooked/mod.rs
+++ b/clients/rust/src/hooked/mod.rs
@@ -256,6 +256,36 @@ impl From<&ExternalPluginAdapterKey> for ExternalPluginAdapterType {
     }
 }
 
+// Create a data slice of the account based on the offset and length passed in.
+pub(crate) fn slice_data<'a>(
+    data_offset: Option<u64>,
+    data_len: Option<u64>,
+    account_data: &'a [u8],
+) -> Result<(&'a [u8], usize, usize), std::io::Error> {
+    let data_offset = data_offset.ok_or(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        MplCoreError::InvalidPlugin.to_string(),
+    ))?;
+
+    let data_len = data_len.ok_or(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        MplCoreError::InvalidPlugin.to_string(),
+    ))?;
+
+    let end = data_offset
+        .checked_add(data_len)
+        .ok_or(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            MplCoreError::NumericalOverflow.to_string(),
+        ))?;
+
+    Ok((
+        &account_data[data_offset as usize..end as usize],
+        data_offset as usize,
+        data_len as usize,
+    ))
+}
+
 /// Use `ExternalPluginAdapterSchema` to convert data to string.  If schema is binary or there is
 /// an error, then use Base64 encoding.
 pub fn convert_external_plugin_adapter_data_to_string(

--- a/clients/rust/src/hooked/mod.rs
+++ b/clients/rust/src/hooked/mod.rs
@@ -256,36 +256,6 @@ impl From<&ExternalPluginAdapterKey> for ExternalPluginAdapterType {
     }
 }
 
-// Create a data slice of the account based on the offset and length passed in.
-pub(crate) fn slice_data<'a>(
-    data_offset: Option<u64>,
-    data_len: Option<u64>,
-    account_data: &'a [u8],
-) -> Result<(&'a [u8], usize, usize), std::io::Error> {
-    let data_offset = data_offset.ok_or(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        MplCoreError::InvalidPlugin.to_string(),
-    ))?;
-
-    let data_len = data_len.ok_or(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        MplCoreError::InvalidPlugin.to_string(),
-    ))?;
-
-    let end = data_offset
-        .checked_add(data_len)
-        .ok_or(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            MplCoreError::NumericalOverflow.to_string(),
-        ))?;
-
-    Ok((
-        &account_data[data_offset as usize..end as usize],
-        data_offset as usize,
-        data_len as usize,
-    ))
-}
-
 /// Use `ExternalPluginAdapterSchema` to convert data to string.  If schema is binary or there is
 /// an error, then use Base64 encoding.
 pub fn convert_external_plugin_adapter_data_to_string(

--- a/clients/rust/src/hooked/plugin.rs
+++ b/clients/rust/src/hooked/plugin.rs
@@ -171,7 +171,7 @@ fn unwrap_data_offset_and_data_len(
 }
 
 /// Fetch the external_plugin_adapter data from the registry and convert to string.
-/// May not be suitable for large amounts of data.
+/// May not be suitable for larger amounts of data.
 pub fn fetch_external_plugin_adapter_data_as_string<T: DataBlob + SolanaAccount>(
     account: &AccountInfo,
     core: Option<&T>,
@@ -208,8 +208,9 @@ pub fn fetch_external_plugin_adapter_data_as_string<T: DataBlob + SolanaAccount>
     Ok((data_string, data_offset, data_len))
 }
 
-/// Fetch the external_plugin_adapter data offset and length.  This can then be used to
+/// Fetch the external plugin adapter data offset and length.  These can be used to
 /// directly slice the account data for use of the external plugin adapter data elsewhere.
+/// This function is more suitable for larger amounts of external plugin adapter data.
 pub fn fetch_external_plugin_adapter_data_info<T: DataBlob + SolanaAccount>(
     account: &AccountInfo,
     core: Option<&T>,

--- a/clients/rust/tests/add_external_plugins.rs
+++ b/clients/rust/tests/add_external_plugins.rs
@@ -320,6 +320,7 @@ async fn test_temporarily_cannot_add_lifecycle_hook_on_collection() {
             num_minted: 0,
             current_size: 0,
             plugins: vec![],
+            external_plugin_adapters: vec![],
         },
     )
     .await;

--- a/clients/rust/tests/create_collection.rs
+++ b/clients/rust/tests/create_collection.rs
@@ -37,6 +37,7 @@ async fn test_create_collection() {
             num_minted: 0,
             current_size: 0,
             plugins: vec![],
+            external_plugin_adapters: vec![],
         },
     )
     .await;
@@ -76,6 +77,7 @@ async fn create_collection_with_different_payer() {
             num_minted: 0,
             current_size: 0,
             plugins: vec![],
+            external_plugin_adapters: vec![],
         },
     )
     .await;
@@ -132,6 +134,7 @@ async fn create_collection_with_plugins() {
                     rule_set: RuleSet::ProgramDenyList(vec![]),
                 }),
             }],
+            external_plugin_adapters: vec![],
         },
     )
     .await;
@@ -172,6 +175,7 @@ async fn create_collection_with_different_update_authority() {
             num_minted: 0,
             current_size: 0,
             plugins: vec![],
+            external_plugin_adapters: vec![],
         },
     )
     .await;
@@ -233,6 +237,7 @@ async fn create_collection_with_plugins_with_different_plugin_authority() {
                     rule_set: RuleSet::ProgramDenyList(vec![]),
                 }),
             }],
+            external_plugin_adapters: vec![],
         },
     )
     .await;

--- a/clients/rust/tests/setup/mod.rs
+++ b/clients/rust/tests/setup/mod.rs
@@ -232,6 +232,7 @@ pub struct AssertCollectionHelperArgs {
     pub current_size: u32,
     // TODO use PluginList type here
     pub plugins: Vec<PluginAuthorityPair>,
+    pub external_plugin_adapters: Vec<ExternalPluginAdapter>,
 }
 
 pub async fn assert_collection(
@@ -285,7 +286,58 @@ pub async fn assert_collection(
         }
     }
 
-    // TODO validate external plugin adapters here.
+    assert_eq!(
+        input.external_plugin_adapters.len(),
+        collection
+            .external_plugin_adapter_list
+            .lifecycle_hooks
+            .len()
+            + collection.external_plugin_adapter_list.oracles.len()
+            + collection.external_plugin_adapter_list.app_data.len()
+    );
+    for plugin in input.external_plugin_adapters {
+        match plugin {
+            ExternalPluginAdapter::LifecycleHook(hook) => {
+                assert!(collection
+                    .external_plugin_adapter_list
+                    .lifecycle_hooks
+                    .iter()
+                    .any(|lifecyle_hook_with_data| lifecyle_hook_with_data.base == hook))
+            }
+            ExternalPluginAdapter::Oracle(oracle) => {
+                assert!(collection
+                    .external_plugin_adapter_list
+                    .oracles
+                    .contains(&oracle))
+            }
+            ExternalPluginAdapter::AppData(app_data) => {
+                assert!(collection
+                    .external_plugin_adapter_list
+                    .app_data
+                    .iter()
+                    .any(|app_data_with_data| app_data_with_data.base == app_data))
+            }
+            ExternalPluginAdapter::LinkedLifecycleHook(hook) => {
+                assert!(collection
+                    .external_plugin_adapter_list
+                    .linked_lifecycle_hooks
+                    .contains(&hook))
+            }
+            ExternalPluginAdapter::LinkedAppData(app_data) => {
+                assert!(collection
+                    .external_plugin_adapter_list
+                    .linked_app_data
+                    .contains(&app_data))
+            }
+            ExternalPluginAdapter::DataSection(data) => {
+                assert!(collection
+                    .external_plugin_adapter_list
+                    .data_sections
+                    .iter()
+                    .any(|data_sections_with_data| data_sections_with_data.base == data))
+            }
+        }
+    }
 }
 
 pub async fn airdrop(

--- a/clients/rust/tests/setup/mod.rs
+++ b/clients/rust/tests/setup/mod.rs
@@ -144,7 +144,8 @@ pub async fn assert_asset(context: &mut ProgramTestContext, input: AssertAssetHe
                 assert!(asset
                     .external_plugin_adapter_list
                     .lifecycle_hooks
-                    .contains(&hook))
+                    .iter()
+                    .any(|lifecyle_hook_with_data| lifecyle_hook_with_data.base == hook))
             }
             ExternalPluginAdapter::Oracle(oracle) => {
                 assert!(asset.external_plugin_adapter_list.oracles.contains(&oracle))
@@ -153,7 +154,8 @@ pub async fn assert_asset(context: &mut ProgramTestContext, input: AssertAssetHe
                 assert!(asset
                     .external_plugin_adapter_list
                     .app_data
-                    .contains(&app_data))
+                    .iter()
+                    .any(|app_data_with_data| app_data_with_data.base == app_data))
             }
             ExternalPluginAdapter::LinkedLifecycleHook(hook) => {
                 assert!(asset
@@ -171,7 +173,8 @@ pub async fn assert_asset(context: &mut ProgramTestContext, input: AssertAssetHe
                 assert!(asset
                     .external_plugin_adapter_list
                     .data_sections
-                    .contains(&data))
+                    .iter()
+                    .any(|data_sections_with_data| data_sections_with_data.base == data))
             }
         }
     }


### PR DESCRIPTION
### Notes
* Added external plugin adapter data offset and length to both `Asset` and `Collection` Rust client types.
* Remove `fetch_external_plugin_adapter_data` that fetches data and converts to string.
* Add `fetch_external_plugin_adapter_data_info` to get only the data offset and length and not convert to string.
  * This is more suitable for handling larger amounts of data.
  * Existing public function `convert_external_plugin_adapter_data_to_string()` could also be used if a user has the schema and the slice and wants to convert to string, which is shown in the tests.

_Note reason I called it "convert" rather than deserialize is because I wanted to avoid terminology confusion.  Yes we are deserializing from binary to human readable JSON string, but in other cases where a raw data type is being converted to JSON it is called serializing, so some people might think of JSON string as "serialized". Also with byte64 its typically called "encoding"._

### Testing
* Added tests such that external plugin data is fetched using `Asset::deserialize()`, `Collection::deserialize()`, and `fetch_external_plugin_adapter_data_info()` for both asset and collection.
* Added testing for `fetch_wrapped_external_plugin_adapter` as before it was only tested by `fetch_external_plugin_adapter_data` which did the string conversion.
* Tested that `Asset` and `Collection` both work in an Anchor program.