### PR TITLE
Update README.md

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -11,7 +11,7 @@ A Umi-compatible JavaScript library for the project.
    ```
 3. Finally, register the library with your Umi instance like so.
    ```ts
-   import { createUmi } from '@metaplex-foundation/umi';
+   import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
    import { mplCore } from '@metaplex-foundation/mpl-core';
 
    const umi = createUmi('<your rpc endpoint>');


### PR DESCRIPTION
@metaplex-foundation/umi -> @metaplex-foundation/umi-bundle-defaults

With the old import I was getting error:

```
InterfaceImplementationMissingError: Tried using ProgramRepositoryInterface but no implementation of that interface was found. Make sure an implementation is registered, e.g. via "context.programs = new MyProgramRepository();".

Source: SDK

```