### PR TITLE
Merge in main

### DIFF
--- a/clients/rust/src/hooked/plugin.rs
+++ b/clients/rust/src/hooked/plugin.rs
@@ -6,7 +6,7 @@ use num_traits::FromPrimitive;
 use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
 
 use crate::{
-    accounts::{BaseAssetV1, PluginHeaderV1},
+    accounts::{BaseAssetV1, BaseCollectionV1, PluginHeaderV1},
     errors::MplCoreError,
     types::{
         ExternalPluginAdapter, ExternalPluginAdapterKey, ExternalPluginAdapterType, LinkedDataKey,
@@ -82,6 +82,22 @@ pub fn fetch_plugin<T: DataBlob + SolanaAccount, U: CrateDeserialize>(
         inner,
         registry_record.offset as usize,
     ))
+}
+
+/// Fetch the plugin on an asset.
+pub fn fetch_asset_plugin<U: CrateDeserialize>(
+    account: &AccountInfo,
+    plugin_type: PluginType,
+) -> Result<(PluginAuthority, U, usize), std::io::Error> {
+    fetch_plugin::<BaseAssetV1, U>(account, plugin_type)
+}
+
+/// Fetch the plugin on a collection.
+pub fn fetch_collection_plugin<U: CrateDeserialize>(
+    account: &AccountInfo,
+    plugin_type: PluginType,
+) -> Result<(PluginAuthority, U, usize), std::io::Error> {
+    fetch_plugin::<BaseCollectionV1, U>(account, plugin_type)
 }
 
 /// Fetch the plugin registry, dropping any unknown plugins (i.e. `PluginType`s that are too new

--- a/programs/mpl-core/src/plugins/autograph.rs
+++ b/programs/mpl-core/src/plugins/autograph.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{program_error::ProgramError, pubkey::Pubkey};
 
-use crate::{error::MplCoreError, plugins::PluginType, state::Authority};
+use crate::error::MplCoreError;
 
 use super::{
     abstain, approve, Plugin, PluginValidation, PluginValidationContext, ValidationResult,
@@ -118,24 +118,6 @@ impl PluginValidation for Autograph {
                 approve!()
             }
             _ => abstain!(),
-        }
-    }
-
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::Autograph
-        {
-            approve!()
-        } else {
-            abstain!()
         }
     }
 }

--- a/programs/mpl-core/src/plugins/burn_delegate.rs
+++ b/programs/mpl-core/src/plugins/burn_delegate.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::program_error::ProgramError;
 
 use crate::{
-    plugins::{abstain, approve, PluginType},
+    plugins::{abstain, approve},
     state::{Authority, DataBlob},
 };
 
@@ -46,24 +46,6 @@ impl PluginValidation for BurnDelegate {
             == (&Authority::Address {
                 address: *ctx.authority_info.key,
             })
-        {
-            approve!()
-        } else {
-            abstain!()
-        }
-    }
-
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::BurnDelegate
         {
             approve!()
         } else {

--- a/programs/mpl-core/src/plugins/edition.rs
+++ b/programs/mpl-core/src/plugins/edition.rs
@@ -1,12 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::program_error::ProgramError;
 
-use crate::{plugins::approve, state::Authority};
-
-use super::{
-    abstain, reject, Plugin, PluginType, PluginValidation, PluginValidationContext,
-    ValidationResult,
-};
+use super::{abstain, reject, Plugin, PluginValidation, PluginValidationContext, ValidationResult};
 
 /// The edition plugin allows the creator to set an edition number on the asset
 /// The default authority for this plugin is the creator.
@@ -43,23 +38,6 @@ impl PluginValidation for Edition {
                 reject!()
             }
             _ => abstain!(),
-        }
-    }
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::Edition
-        {
-            approve!()
-        } else {
-            abstain!()
         }
     }
 }

--- a/programs/mpl-core/src/plugins/external_plugin_adapters.rs
+++ b/programs/mpl-core/src/plugins/external_plugin_adapters.rs
@@ -7,6 +7,7 @@ use strum::EnumCount;
 
 use crate::{
     error::MplCoreError,
+    plugins::lifecycle::{approve, reject},
     state::{AssetV1, SolanaAccount},
 };
 
@@ -268,6 +269,53 @@ impl ExternalPluginAdapter {
             }
             // Here we block the creation of a DataSection plugin because this is only done internally.
             ExternalPluginAdapter::DataSection(_) => Ok(ValidationResult::Rejected),
+        }
+    }
+
+    /// Validate the add external plugin adapter lifecycle event.
+    pub(crate) fn validate_update_external_plugin_adapter(
+        external_plugin_adapter: &ExternalPluginAdapter,
+        ctx: &PluginValidationContext,
+    ) -> Result<ValidationResult, ProgramError> {
+        let resolved_authorities = ctx
+            .resolved_authorities
+            .ok_or(MplCoreError::InvalidAuthority)?;
+        let base_result = if resolved_authorities.contains(ctx.self_authority) {
+            solana_program::msg!("Base: Approved");
+            ValidationResult::Approved
+        } else {
+            ValidationResult::Pass
+        };
+
+        let result = match external_plugin_adapter {
+            ExternalPluginAdapter::LifecycleHook(lifecycle_hook) => {
+                lifecycle_hook.validate_update_external_plugin_adapter(ctx)
+            }
+            ExternalPluginAdapter::Oracle(oracle) => {
+                oracle.validate_update_external_plugin_adapter(ctx)
+            }
+            ExternalPluginAdapter::DataStore(app_data) => {
+                app_data.validate_update_external_plugin_adapter(ctx)
+            }
+        }?;
+
+        match (&base_result, &result) {
+            (ValidationResult::Approved, ValidationResult::Approved) => {
+                approve!()
+            }
+            (ValidationResult::Approved, ValidationResult::Rejected) => {
+                reject!()
+            }
+            (ValidationResult::Rejected, ValidationResult::Approved) => {
+                reject!()
+            }
+            (ValidationResult::Rejected, ValidationResult::Rejected) => {
+                reject!()
+            }
+            (ValidationResult::Pass, _) => Ok(result),
+            (ValidationResult::ForceApproved, _) => unreachable!(),
+            (_, ValidationResult::Pass) => Ok(base_result),
+            (_, ValidationResult::ForceApproved) => unreachable!(),
         }
     }
 

--- a/programs/mpl-core/src/plugins/external_plugin_adapters.rs
+++ b/programs/mpl-core/src/plugins/external_plugin_adapters.rs
@@ -294,9 +294,17 @@ impl ExternalPluginAdapter {
             ExternalPluginAdapter::Oracle(oracle) => {
                 oracle.validate_update_external_plugin_adapter(ctx)
             }
-            ExternalPluginAdapter::DataStore(app_data) => {
+            ExternalPluginAdapter::AppData(app_data) => {
                 app_data.validate_update_external_plugin_adapter(ctx)
             }
+            ExternalPluginAdapter::LinkedLifecycleHook(lifecycle_hook) => {
+                lifecycle_hook.validate_update_external_plugin_adapter(ctx)
+            }
+            ExternalPluginAdapter::LinkedAppData(app_data) => {
+                app_data.validate_update_external_plugin_adapter(ctx)
+            }
+            // Here we block the update of a DataSection plugin because this is only done internally.
+            ExternalPluginAdapter::DataSection(_) => Ok(ValidationResult::Rejected),
         }?;
 
         match (&base_result, &result) {

--- a/programs/mpl-core/src/plugins/permanent_burn_delegate.rs
+++ b/programs/mpl-core/src/plugins/permanent_burn_delegate.rs
@@ -4,7 +4,7 @@ use solana_program::program_error::ProgramError;
 use crate::state::DataBlob;
 
 use super::{
-    abstain, approve, force_approve, reject, PluginType, PluginValidation, PluginValidationContext,
+    abstain, force_approve, reject, PluginType, PluginValidation, PluginValidationContext,
     ValidationResult,
 };
 
@@ -38,13 +38,6 @@ impl PluginValidation for PermanentBurnDelegate {
         } else {
             abstain!()
         }
-    }
-
-    fn validate_revoke_plugin_authority(
-        &self,
-        _ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        approve!()
     }
 
     fn validate_burn(

--- a/programs/mpl-core/src/plugins/permanent_freeze_delegate.rs
+++ b/programs/mpl-core/src/plugins/permanent_freeze_delegate.rs
@@ -3,10 +3,10 @@ use solana_program::program_error::ProgramError;
 
 use crate::{
     plugins::{reject, PluginType},
-    state::{Authority, DataBlob},
+    state::DataBlob,
 };
 
-use super::{abstain, approve, PluginValidation, PluginValidationContext, ValidationResult};
+use super::{abstain, PluginValidation, PluginValidationContext, ValidationResult};
 
 /// The permanent freeze plugin allows any authority to lock the asset so it's no longer transferable.
 /// The default authority for this plugin is the update authority.
@@ -73,24 +73,6 @@ impl PluginValidation for PermanentFreezeDelegate {
             && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::PermanentFreezeDelegate
         {
             reject!()
-        } else {
-            abstain!()
-        }
-    }
-
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::PermanentFreezeDelegate
-        {
-            approve!()
         } else {
             abstain!()
         }

--- a/programs/mpl-core/src/plugins/permanent_transfer_delegate.rs
+++ b/programs/mpl-core/src/plugins/permanent_transfer_delegate.rs
@@ -4,7 +4,7 @@ use solana_program::program_error::ProgramError;
 use crate::state::DataBlob;
 
 use super::{
-    abstain, approve, force_approve, reject, PluginType, PluginValidation, PluginValidationContext,
+    abstain, force_approve, reject, PluginType, PluginValidation, PluginValidationContext,
     ValidationResult,
 };
 
@@ -38,13 +38,6 @@ impl PluginValidation for PermanentTransferDelegate {
         } else {
             abstain!()
         }
-    }
-
-    fn validate_revoke_plugin_authority(
-        &self,
-        _ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        approve!()
     }
 
     fn validate_transfer(

--- a/programs/mpl-core/src/plugins/royalties.rs
+++ b/programs/mpl-core/src/plugins/royalties.rs
@@ -3,11 +3,9 @@ use std::collections::HashSet;
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{program_error::ProgramError, pubkey::Pubkey};
 
-use crate::{error::MplCoreError, plugins::PluginType, state::Authority};
+use crate::error::MplCoreError;
 
-use super::{
-    abstain, approve, reject, Plugin, PluginValidation, PluginValidationContext, ValidationResult,
-};
+use super::{abstain, reject, Plugin, PluginValidation, PluginValidationContext, ValidationResult};
 
 /// The creator on an asset and whether or not they are verified.
 #[derive(Clone, BorshSerialize, BorshDeserialize, Debug, PartialEq, Eq)]
@@ -128,24 +126,6 @@ impl PluginValidation for Royalties {
             } else {
                 abstain!()
             }
-        } else {
-            abstain!()
-        }
-    }
-
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::Royalties
-        {
-            approve!()
         } else {
             abstain!()
         }

--- a/programs/mpl-core/src/plugins/transfer.rs
+++ b/programs/mpl-core/src/plugins/transfer.rs
@@ -1,10 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::program_error::ProgramError;
 
-use crate::{
-    plugins::PluginType,
-    state::{Authority, DataBlob},
-};
+use crate::state::{Authority, DataBlob};
 
 use super::{abstain, approve, PluginValidation, PluginValidationContext, ValidationResult};
 
@@ -74,23 +71,5 @@ impl PluginValidation for TransferDelegate {
             _ => {}
         }
         abstain!()
-    }
-
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::TransferDelegate
-        {
-            approve!()
-        } else {
-            abstain!()
-        }
     }
 }

--- a/programs/mpl-core/src/plugins/utils.rs
+++ b/programs/mpl-core/src/plugins/utils.rs
@@ -810,69 +810,94 @@ pub(crate) fn find_external_plugin_adapter<'b>(
     plugin_key: &ExternalPluginAdapterKey,
     account: &AccountInfo<'_>,
 ) -> Result<(Option<usize>, Option<&'b ExternalRegistryRecord>), ProgramError> {
-    let mut result = (None, None);
     for (i, record) in plugin_registry.external_registry.iter().enumerate() {
-        if record.plugin_type == ExternalPluginAdapterType::from(plugin_key)
-            && (match plugin_key {
-                ExternalPluginAdapterKey::LifecycleHook(address)
-                | ExternalPluginAdapterKey::Oracle(address)
-                | ExternalPluginAdapterKey::LinkedLifecycleHook(address) => {
-                    let pubkey_offset = record
-                        .offset
-                        .checked_add(1)
-                        .ok_or(MplCoreError::NumericalOverflow)?;
-                    address
-                        == &match Pubkey::deserialize(&mut &account.data.borrow()[pubkey_offset..])
-                        {
-                            Ok(address) => address,
-                            Err(_) => return Err(MplCoreError::DeserializationError.into()),
-                        }
-                }
-                ExternalPluginAdapterKey::AppData(authority) => {
-                    let authority_offset = record
-                        .offset
-                        .checked_add(1)
-                        .ok_or(MplCoreError::NumericalOverflow)?;
-                    authority
-                        == &match Authority::deserialize(
-                            &mut &account.data.borrow()[authority_offset..],
-                        ) {
-                            Ok(authority) => authority,
-                            Err(_) => return Err(MplCoreError::DeserializationError.into()),
-                        }
-                }
-                ExternalPluginAdapterKey::LinkedAppData(authority) => {
-                    let authority_offset = record
-                        .offset
-                        .checked_add(1)
-                        .ok_or(MplCoreError::NumericalOverflow)?;
-                    authority
-                        == &match Authority::deserialize(
-                            &mut &account.data.borrow()[authority_offset..],
-                        ) {
-                            Ok(authority) => authority,
-                            Err(_) => return Err(MplCoreError::DeserializationError.into()),
-                        }
-                }
-                ExternalPluginAdapterKey::DataSection(linked_data_key) => {
-                    let linked_data_key_offset = record
-                        .offset
-                        .checked_add(1)
-                        .ok_or(MplCoreError::NumericalOverflow)?;
-                    linked_data_key
-                        == &match LinkedDataKey::deserialize(
-                            &mut &account.data.borrow()[linked_data_key_offset..],
-                        ) {
-                            Ok(linked_data_key) => linked_data_key,
-                            Err(_) => return Err(MplCoreError::DeserializationError.into()),
-                        }
-                }
-            })
-        {
-            result = (Some(i), Some(record));
-            break;
+        if check_plugin_key(record, plugin_key, account)? {
+            return Ok((Some(i), Some(record)));
         }
     }
 
-    Ok(result)
+    Ok((None, None))
+}
+
+pub(crate) fn find_external_plugin_adapter_mut<'b>(
+    plugin_registry: &'b mut PluginRegistryV1,
+    plugin_key: &ExternalPluginAdapterKey,
+    account: &AccountInfo<'_>,
+) -> Result<(Option<usize>, Option<&'b mut ExternalRegistryRecord>), ProgramError> {
+    for (i, record) in plugin_registry.external_registry.iter_mut().enumerate() {
+        let record_ref = &*record;
+
+        if check_plugin_key(record_ref, plugin_key, account)? {
+            return Ok((Some(i), Some(record)));
+        }
+    }
+
+    Ok((None, None))
+}
+
+fn check_plugin_key(
+    record_ref: &ExternalRegistryRecord,
+    plugin_key: &ExternalPluginAdapterKey,
+    account: &AccountInfo,
+) -> Result<bool, ProgramError> {
+    if record_ref.plugin_type == ExternalPluginAdapterType::from(plugin_key)
+        && (match plugin_key {
+            ExternalPluginAdapterKey::LifecycleHook(address)
+            | ExternalPluginAdapterKey::Oracle(address)
+            | ExternalPluginAdapterKey::LinkedLifecycleHook(address) => {
+                let pubkey_offset = record_ref
+                    .offset
+                    .checked_add(1)
+                    .ok_or(MplCoreError::NumericalOverflow)?;
+                address
+                    == &match Pubkey::deserialize(&mut &account.data.borrow()[pubkey_offset..]) {
+                        Ok(address) => address,
+                        Err(_) => return Err(MplCoreError::DeserializationError.into()),
+                    }
+            }
+            ExternalPluginAdapterKey::AppData(authority) => {
+                let authority_offset = record_ref
+                    .offset
+                    .checked_add(1)
+                    .ok_or(MplCoreError::NumericalOverflow)?;
+                authority
+                    == &match Authority::deserialize(
+                        &mut &account.data.borrow()[authority_offset..],
+                    ) {
+                        Ok(authority) => authority,
+                        Err(_) => return Err(MplCoreError::DeserializationError.into()),
+                    }
+            }
+            ExternalPluginAdapterKey::LinkedAppData(authority) => {
+                let authority_offset = record_ref
+                    .offset
+                    .checked_add(1)
+                    .ok_or(MplCoreError::NumericalOverflow)?;
+                authority
+                    == &match Authority::deserialize(
+                        &mut &account.data.borrow()[authority_offset..],
+                    ) {
+                        Ok(authority) => authority,
+                        Err(_) => return Err(MplCoreError::DeserializationError.into()),
+                    }
+            }
+            ExternalPluginAdapterKey::DataSection(linked_data_key) => {
+                let linked_data_key_offset = record_ref
+                    .offset
+                    .checked_add(1)
+                    .ok_or(MplCoreError::NumericalOverflow)?;
+                linked_data_key
+                    == &match LinkedDataKey::deserialize(
+                        &mut &account.data.borrow()[linked_data_key_offset..],
+                    ) {
+                        Ok(linked_data_key) => linked_data_key,
+                        Err(_) => return Err(MplCoreError::DeserializationError.into()),
+                    }
+            }
+        })
+    {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }

--- a/programs/mpl-core/src/plugins/utils.rs
+++ b/programs/mpl-core/src/plugins/utils.rs
@@ -855,20 +855,8 @@ fn check_plugin_key(
                         Err(_) => return Err(MplCoreError::DeserializationError.into()),
                     }
             }
-            ExternalPluginAdapterKey::AppData(authority) => {
-                let authority_offset = record_ref
-                    .offset
-                    .checked_add(1)
-                    .ok_or(MplCoreError::NumericalOverflow)?;
-                authority
-                    == &match Authority::deserialize(
-                        &mut &account.data.borrow()[authority_offset..],
-                    ) {
-                        Ok(authority) => authority,
-                        Err(_) => return Err(MplCoreError::DeserializationError.into()),
-                    }
-            }
-            ExternalPluginAdapterKey::LinkedAppData(authority) => {
+            ExternalPluginAdapterKey::AppData(authority)
+            | ExternalPluginAdapterKey::LinkedAppData(authority) => {
                 let authority_offset = record_ref
                     .offset
                     .checked_add(1)

--- a/programs/mpl-core/src/plugins/verified_creators.rs
+++ b/programs/mpl-core/src/plugins/verified_creators.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{program_error::ProgramError, pubkey::Pubkey};
 
-use crate::{error::MplCoreError, plugins::PluginType, state::Authority};
+use crate::error::MplCoreError;
 
 use super::{abstain, Plugin, PluginValidation, PluginValidationContext, ValidationResult};
 
@@ -194,25 +194,6 @@ impl PluginValidation for VerifiedCreators {
                 }
             }
             _ => abstain!(),
-        }
-    }
-
-    /// Validate the revoke plugin authority lifecycle action.
-    fn validate_revoke_plugin_authority(
-        &self,
-        ctx: &PluginValidationContext,
-    ) -> Result<ValidationResult, ProgramError> {
-        if ctx.self_authority
-            == &(Authority::Address {
-                address: *ctx.authority_info.key,
-            })
-            && ctx.target_plugin.is_some()
-            && PluginType::from(ctx.target_plugin.unwrap()) == PluginType::VerifiedCreators
-        {
-            solana_program::msg!("Verified creators: Approved");
-            Ok(ValidationResult::Approved)
-        } else {
-            abstain!()
         }
     }
 }

--- a/programs/mpl-core/src/processor/update_external_plugin_adapter.rs
+++ b/programs/mpl-core/src/processor/update_external_plugin_adapter.rs
@@ -10,14 +10,14 @@ use crate::{
         UpdateCollectionExternalPluginAdapterV1Accounts, UpdateExternalPluginAdapterV1Accounts,
     },
     plugins::{
-        fetch_wrapped_external_plugin_adapter, find_external_plugin_adapter, ExternalPluginAdapter,
-        ExternalPluginAdapterKey, ExternalPluginAdapterUpdateInfo, Plugin, PluginHeaderV1,
-        PluginRegistryV1, PluginType,
+        fetch_wrapped_external_plugin_adapter, find_external_plugin_adapter_mut,
+        ExternalPluginAdapter, ExternalPluginAdapterKey, ExternalPluginAdapterUpdateInfo,
+        PluginHeaderV1, PluginRegistryV1, PluginValidationContext, ValidationResult,
     },
     state::{AssetV1, CollectionV1, DataBlob, Key, SolanaAccount},
     utils::{
-        load_key, resize_or_reallocate_account, resolve_authority, validate_asset_permissions,
-        validate_collection_permissions,
+        fetch_core_data, load_key, resize_or_reallocate_account, resolve_authority,
+        resolve_pubkey_to_authorities, resolve_pubkey_to_authorities_collection,
     },
 };
 
@@ -56,34 +56,40 @@ pub(crate) fn update_external_plugin_adapter<'a>(
         return Err(MplCoreError::NotAvailable.into());
     }
 
-    let (_, plugin) =
+    let (mut asset, plugin_header, plugin_registry) =
+        fetch_core_data::<AssetV1>(ctx.accounts.asset)?;
+    let resolved_authorities =
+        resolve_pubkey_to_authorities(authority, ctx.accounts.collection, &asset)?;
+    let (external_registry_record, external_plugin_adapter) =
         fetch_wrapped_external_plugin_adapter::<AssetV1>(ctx.accounts.asset, None, &args.key)?;
 
-    let (mut asset, plugin_header, plugin_registry) = validate_asset_permissions(
+    let validation_ctx = PluginValidationContext {
         accounts,
-        authority,
-        ctx.accounts.asset,
-        ctx.accounts.collection,
-        None,
-        None,
-        None,
-        Some(&plugin),
-        AssetV1::check_update_external_plugin_adapter,
-        CollectionV1::check_update_external_plugin_adapter,
-        PluginType::check_update_external_plugin_adapter,
-        AssetV1::validate_update_external_plugin_adapter,
-        CollectionV1::validate_update_external_plugin_adapter,
-        Plugin::validate_update_external_plugin_adapter,
-        None,
-        None,
-    )?;
+        asset_info: Some(ctx.accounts.asset),
+        collection_info: ctx.accounts.collection,
+        self_authority: &external_registry_record.authority,
+        authority_info: authority,
+        resolved_authorities: Some(&resolved_authorities),
+        new_owner: None,
+        new_asset_authority: None,
+        new_collection_authority: None,
+        target_plugin: None,
+    };
+
+    if ExternalPluginAdapter::validate_update_external_plugin_adapter(
+        &external_plugin_adapter,
+        &validation_ctx,
+    )? != ValidationResult::Approved
+    {
+        return Err(MplCoreError::InvalidAuthority.into());
+    }
 
     // Increment sequence number and save only if it is `Some(_)`.
     asset.increment_seq_and_save(ctx.accounts.asset)?;
 
     process_update_external_plugin_adapter(
         asset,
-        plugin,
+        external_plugin_adapter,
         args.key,
         args.update_info,
         plugin_header,
@@ -124,31 +130,41 @@ pub(crate) fn update_collection_external_plugin_adapter<'a>(
         }
     }
 
-    let (_, plugin) = fetch_wrapped_external_plugin_adapter::<CollectionV1>(
-        ctx.accounts.collection,
-        None,
-        &args.key,
-    )?;
+    let (collection, plugin_header, plugin_registry) =
+        fetch_core_data::<CollectionV1>(ctx.accounts.collection)?;
+    let resolved_authorities =
+        resolve_pubkey_to_authorities_collection(authority, ctx.accounts.collection)?;
+    let (external_registry_record, external_plugin_adapter) =
+        fetch_wrapped_external_plugin_adapter::<CollectionV1>(
+            ctx.accounts.collection,
+            None,
+            &args.key,
+        )?;
 
-    // Validate collection permissions.
-    let (collection, plugin_header, plugin_registry) = validate_collection_permissions(
+    let validation_ctx = PluginValidationContext {
         accounts,
-        authority,
-        ctx.accounts.collection,
-        None,
-        None,
-        Some(&plugin),
-        CollectionV1::check_update_external_plugin_adapter,
-        PluginType::check_update_external_plugin_adapter,
-        CollectionV1::validate_update_external_plugin_adapter,
-        Plugin::validate_update_external_plugin_adapter,
-        None,
-        None,
-    )?;
+        asset_info: None,
+        collection_info: Some(ctx.accounts.collection),
+        self_authority: &external_registry_record.authority,
+        authority_info: authority,
+        resolved_authorities: Some(&resolved_authorities),
+        new_owner: None,
+        new_asset_authority: None,
+        new_collection_authority: None,
+        target_plugin: None,
+    };
+
+    if ExternalPluginAdapter::validate_update_external_plugin_adapter(
+        &external_plugin_adapter,
+        &validation_ctx,
+    )? != ValidationResult::Approved
+    {
+        return Err(MplCoreError::InvalidAuthority.into());
+    }
 
     process_update_external_plugin_adapter(
         collection,
-        plugin,
+        external_plugin_adapter,
         args.key,
         args.update_info,
         plugin_header,
@@ -174,10 +190,19 @@ fn process_update_external_plugin_adapter<'a, T: DataBlob + SolanaAccount>(
     let mut plugin_registry = plugin_registry.ok_or(MplCoreError::PluginsNotInitialized)?;
     let mut plugin_header = plugin_header.ok_or(MplCoreError::PluginsNotInitialized)?;
 
-    let plugin_registry_clone = plugin_registry.clone();
-    let (_, record) = find_external_plugin_adapter(&plugin_registry_clone, &key, account)?;
-    let mut registry_record = record.ok_or(MplCoreError::PluginNotFound)?.clone();
+    // Update the registry record using a mutable reference that ties back to `plugin_registry`.
+    let (_, record) = find_external_plugin_adapter_mut(&mut plugin_registry, &key, account)?;
+    let registry_record = record.ok_or(MplCoreError::PluginNotFound)?;
+    let old_registry_record_size = registry_record.try_to_vec()?.len() as isize;
+
     registry_record.update(&update_info)?;
+    let new_registry_record_size = registry_record.try_to_vec()?.len() as isize;
+    let registry_record_size_diff = new_registry_record_size
+        .checked_sub(old_registry_record_size)
+        .ok_or(MplCoreError::NumericalOverflow)?;
+
+    // Clone into a new copy, dropping the mutable reference so that `plugin_registry` can be mutably borrowed again later.
+    let registry_record = registry_record.clone();
 
     let mut new_plugin = plugin.clone();
     new_plugin.update(&update_info);
@@ -187,19 +212,21 @@ fn process_update_external_plugin_adapter<'a, T: DataBlob + SolanaAccount>(
 
     // The difference in size between the new and old account which is used to calculate the new size of the account.
     let plugin_size = plugin_data.len() as isize;
-    let size_diff = (new_plugin_data.len() as isize)
+    let plugin_size_diff = (new_plugin_data.len() as isize)
         .checked_sub(plugin_size)
         .ok_or(MplCoreError::NumericalOverflow)?;
 
     // The new size of the account.
     let new_size = (account.data_len() as isize)
-        .checked_add(size_diff)
+        .checked_add(plugin_size_diff)
+        .ok_or(MplCoreError::NumericalOverflow)?
+        .checked_add(registry_record_size_diff)
         .ok_or(MplCoreError::NumericalOverflow)?;
 
     // The new offset of the plugin registry is the old offset plus the size difference.
     let registry_offset = plugin_header.plugin_registry_offset;
     let new_registry_offset = (registry_offset as isize)
-        .checked_add(size_diff)
+        .checked_add(plugin_size_diff)
         .ok_or(MplCoreError::NumericalOverflow)?;
     plugin_header.plugin_registry_offset = new_registry_offset as usize;
 
@@ -209,7 +236,7 @@ fn process_update_external_plugin_adapter<'a, T: DataBlob + SolanaAccount>(
         .ok_or(MplCoreError::NumericalOverflow)?;
 
     let new_next_plugin_offset = next_plugin_offset
-        .checked_add(size_diff)
+        .checked_add(plugin_size_diff)
         .ok_or(MplCoreError::NumericalOverflow)?;
 
     // //TODO: This is memory intensive, we should use memmove instead probably.
@@ -226,7 +253,7 @@ fn process_update_external_plugin_adapter<'a, T: DataBlob + SolanaAccount>(
     plugin_header.save(account, core.get_size())?;
 
     // Move offsets for existing registry records.
-    plugin_registry.bump_offsets(registry_record.offset, size_diff)?;
+    plugin_registry.bump_offsets(registry_record.offset, plugin_size_diff)?;
 
     plugin_registry.save(account, new_registry_offset as usize)?;
     new_plugin.save(account, registry_record.offset)?;

--- a/programs/mpl-core/src/state/asset.rs
+++ b/programs/mpl-core/src/state/asset.rs
@@ -125,7 +125,7 @@ impl AssetV1 {
 
     /// Check permissions for the update external plugin adapter lifecycle event.
     pub fn check_update_external_plugin_adapter() -> CheckResult {
-        CheckResult::CanApprove
+        CheckResult::None
     }
 
     /// Validate the add plugin lifecycle event.
@@ -328,15 +328,11 @@ impl AssetV1 {
     /// Validate the update external plugin adapter lifecycle event.
     pub fn validate_update_external_plugin_adapter(
         &self,
-        authority_info: &AccountInfo,
+        _authority_info: &AccountInfo,
         _: Option<&Plugin>,
         _plugin: Option<&ExternalPluginAdapter>,
     ) -> Result<ValidationResult, ProgramError> {
-        if self.update_authority == UpdateAuthority::Address(*authority_info.key) {
-            approve!()
-        } else {
-            abstain!()
-        }
+        abstain!()
     }
 }
 

--- a/programs/mpl-core/src/state/collection.rs
+++ b/programs/mpl-core/src/state/collection.rs
@@ -110,7 +110,7 @@ impl CollectionV1 {
 
     /// Check permissions for the update external plugin adapter lifecycle event.
     pub fn check_update_external_plugin_adapter() -> CheckResult {
-        CheckResult::CanApprove
+        CheckResult::None
     }
 
     /// Validate the add plugin lifecycle event.
@@ -293,15 +293,11 @@ impl CollectionV1 {
     /// Validate the update external plugin adapter lifecycle event.
     pub fn validate_update_external_plugin_adapter(
         &self,
-        authority_info: &AccountInfo,
+        _authority_info: &AccountInfo,
         _: Option<&Plugin>,
         _plugin: Option<&ExternalPluginAdapter>,
     ) -> Result<ValidationResult, ProgramError> {
-        if self.update_authority == *authority_info.key {
-            approve!()
-        } else {
-            abstain!()
-        }
+        abstain!()
     }
 
     /// Increment number of minted items of the Collection


### PR DESCRIPTION
### Notes
* Merge in main
* Rename `DataStore` external plugin adapter, and add handling for external plugin adapters that were already on jun-2024-feature-staging branch but not main.

### Analysis
* I diffed oracle.test.ts and revokeAuthority.test.ts with what is on main and they match.
* I looked at each of the other changes and tracked them to the changes in PRs 169-172.
* Looks like the removal of `validate_revoke_plugin_authority` in update_delegate.rs was not included which I think makes sense because it was updated to handle multiple update delegates.