### PR TITLE
Add AppData auth tests

### DIFF
--- a/clients/js/src/plugins/appData.ts
+++ b/clients/js/src/plugins/appData.ts
@@ -54,7 +54,7 @@ export function appDataInitInfoArgsToBase(
     initPluginAuthority: d.initPluginAuthority
       ? pluginAuthorityToBase(d.initPluginAuthority)
       : null,
-    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
+    schema: d.schema ?? null,
   };
 }
 
@@ -62,7 +62,7 @@ export function appDataUpdateInfoArgsToBase(
   d: AppDataUpdateInfoArgs
 ): BaseAppDataUpdateInfoArgs {
   return {
-    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
+    schema: d.schema ?? null,
   };
 }
 

--- a/clients/js/src/plugins/appData.ts
+++ b/clients/js/src/plugins/appData.ts
@@ -54,7 +54,7 @@ export function appDataInitInfoArgsToBase(
     initPluginAuthority: d.initPluginAuthority
       ? pluginAuthorityToBase(d.initPluginAuthority)
       : null,
-    schema: d.schema ? d.schema : null,
+    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
   };
 }
 
@@ -62,7 +62,7 @@ export function appDataUpdateInfoArgsToBase(
   d: AppDataUpdateInfoArgs
 ): BaseAppDataUpdateInfoArgs {
   return {
-    schema: d.schema ? d.schema : null,
+    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
   };
 }
 

--- a/clients/js/src/plugins/lifecycleHook.ts
+++ b/clients/js/src/plugins/lifecycleHook.ts
@@ -75,7 +75,7 @@ export function lifecycleHookInitInfoArgsToBase(
       ? pluginAuthorityToBase(l.initPluginAuthority)
       : null,
     lifecycleChecks: lifecycleChecksToBase(l.lifecycleChecks),
-    schema: l.schema ? l.schema : null,
+    schema: l.schema ?? null,
     dataAuthority: l.dataAuthority
       ? pluginAuthorityToBase(l.dataAuthority)
       : null,
@@ -92,7 +92,7 @@ export function lifecycleHookUpdateInfoArgsToBase(
     extraAccounts: l.extraAccounts
       ? l.extraAccounts.map(extraAccountToBase)
       : null,
-    schema: l.schema ? l.schema : null,
+    schema: l.schema ?? null,
     // TODO update dataAuthority?
   };
 }

--- a/clients/js/src/plugins/linkedAppData.ts
+++ b/clients/js/src/plugins/linkedAppData.ts
@@ -53,7 +53,7 @@ export function linkedAppDataInitInfoArgsToBase(
     initPluginAuthority: d.initPluginAuthority
       ? pluginAuthorityToBase(d.initPluginAuthority)
       : null,
-    schema: d.schema ? d.schema : null,
+    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
   };
 }
 
@@ -61,7 +61,7 @@ export function linkedAppDataUpdateInfoArgsToBase(
   d: LinkedAppDataUpdateInfoArgs
 ): BaseLinkedAppDataUpdateInfoArgs {
   return {
-    schema: d.schema ? d.schema : null,
+    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
   };
 }
 

--- a/clients/js/src/plugins/linkedAppData.ts
+++ b/clients/js/src/plugins/linkedAppData.ts
@@ -53,7 +53,7 @@ export function linkedAppDataInitInfoArgsToBase(
     initPluginAuthority: d.initPluginAuthority
       ? pluginAuthorityToBase(d.initPluginAuthority)
       : null,
-    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
+    schema: d.schema ?? null,
   };
 }
 
@@ -61,7 +61,7 @@ export function linkedAppDataUpdateInfoArgsToBase(
   d: LinkedAppDataUpdateInfoArgs
 ): BaseLinkedAppDataUpdateInfoArgs {
   return {
-    schema: d.schema !== undefined && d.schema !== null ? d.schema : null,
+    schema: d.schema ?? null,
   };
 }
 

--- a/clients/js/src/plugins/linkedLifecycleHook.ts
+++ b/clients/js/src/plugins/linkedLifecycleHook.ts
@@ -92,7 +92,7 @@ export function linkedLifecycleHookUpdateInfoArgsToBase(
     extraAccounts: l.extraAccounts
       ? l.extraAccounts.map(extraAccountToBase)
       : null,
-    schema: l.schema ? l.schema : null,
+    schema: l.schema ?? null,
   };
 }
 

--- a/clients/js/test/externalPlugins/appData.test.ts
+++ b/clients/js/test/externalPlugins/appData.test.ts
@@ -610,7 +610,7 @@ test('it can update app data with external plugin authority different than asset
   });
 });
 
-test('it cannot update oracle using update authority when different from external plugin authority', async (t) => {
+test('it cannot update app data using update authority when different from external plugin authority', async (t) => {
   const umi = await createUmi();
   const asset = generateSigner(umi);
   const dataAuthority = generateSigner(umi);
@@ -687,7 +687,7 @@ test('it cannot update oracle using update authority when different from externa
   });
 });
 
-test('it can update oracle on collection with external plugin authority different than asset update authority', async (t) => {
+test('it can update app data on collection with external plugin authority different than asset update authority', async (t) => {
   const umi = await createUmi();
   const collection = generateSigner(umi);
   const dataAuthority = generateSigner(umi);
@@ -760,7 +760,7 @@ test('it can update oracle on collection with external plugin authority differen
   });
 });
 
-test('it cannot update oracle on collection using update authority when different from external plugin authority', async (t) => {
+test('it cannot update app data on collection using update authority when different from external plugin authority', async (t) => {
   const umi = await createUmi();
   const collection = generateSigner(umi);
   const dataAuthority = generateSigner(umi);

--- a/clients/js/test/externalPlugins/appData.test.ts
+++ b/clients/js/test/externalPlugins/appData.test.ts
@@ -1,8 +1,13 @@
 import test from 'ava';
 import { generateSignerWithSol } from '@metaplex-foundation/umi-bundle-tests';
-import { Signer, Umi } from '@metaplex-foundation/umi';
+import { Signer, Umi, generateSigner } from '@metaplex-foundation/umi';
 import * as msgpack from '@msgpack/msgpack';
-import { assertAsset, createUmi, DEFAULT_ASSET } from '../_setupRaw';
+import {
+  assertAsset,
+  createUmi,
+  DEFAULT_ASSET,
+  assertCollection,
+} from '../_setupRaw';
 import { createAsset } from '../_setupSdk';
 import {
   ExternalPluginAdapterSchema,
@@ -10,6 +15,9 @@ import {
   PluginAuthorityType,
   updatePlugin,
   writeData,
+  create,
+  createCollection,
+  updateCollectionPlugin,
 } from '../../src';
 
 const DATA_AUTHORITIES: PluginAuthorityType[] = [
@@ -522,6 +530,306 @@ test(`updating a plugin before a secure app data does not corrupt the data`, asy
         dataAuthority,
         schema: ExternalPluginAdapterSchema.Json,
         data: assertData,
+      },
+    ],
+  });
+});
+
+test('it can update app data with external plugin authority different than asset update authority', async (t) => {
+  const umi = await createUmi();
+  const asset = generateSigner(umi);
+  const dataAuthority = generateSigner(umi);
+  const appDataUpdateAuthority = generateSigner(umi);
+
+  await create(umi, {
+    asset,
+    name: 'Test name',
+    uri: 'https://example.com',
+    plugins: [
+      {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+        initPluginAuthority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+      },
+    ],
+  }).sendAndConfirm(umi);
+
+  await assertAsset(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    owner: umi.identity.publicKey,
+    asset: asset.publicKey,
+    updateAuthority: { type: 'Address', address: umi.identity.publicKey },
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+
+  await updatePlugin(umi, {
+    asset: asset.publicKey,
+    authority: appDataUpdateAuthority,
+    plugin: {
+      key: {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+      },
+      type: 'AppData',
+      schema: ExternalPluginAdapterSchema.Binary,
+    },
+  }).sendAndConfirm(umi);
+
+  await assertAsset(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    owner: umi.identity.publicKey,
+    asset: asset.publicKey,
+    updateAuthority: { type: 'Address', address: umi.identity.publicKey },
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Binary,
+      },
+    ],
+  });
+});
+
+test('it cannot update oracle using update authority when different from external plugin authority', async (t) => {
+  const umi = await createUmi();
+  const asset = generateSigner(umi);
+  const dataAuthority = generateSigner(umi);
+  const appDataUpdateAuthority = generateSigner(umi);
+
+  await create(umi, {
+    asset,
+    name: 'Test name',
+    uri: 'https://example.com',
+    plugins: [
+      {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+        initPluginAuthority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+      },
+    ],
+  }).sendAndConfirm(umi);
+
+  await assertAsset(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    owner: umi.identity.publicKey,
+    asset: asset.publicKey,
+    updateAuthority: { type: 'Address', address: umi.identity.publicKey },
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+
+  const result = updatePlugin(umi, {
+    asset: asset.publicKey,
+    authority: umi.identity,
+    plugin: {
+      key: {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+      },
+      type: 'AppData',
+      schema: ExternalPluginAdapterSchema.Binary,
+    },
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'InvalidAuthority' });
+
+  await assertAsset(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    owner: umi.identity.publicKey,
+    asset: asset.publicKey,
+    updateAuthority: { type: 'Address', address: umi.identity.publicKey },
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+});
+
+test('it can update oracle on collection with external plugin authority different than asset update authority', async (t) => {
+  const umi = await createUmi();
+  const collection = generateSigner(umi);
+  const dataAuthority = generateSigner(umi);
+  const appDataUpdateAuthority = generateSigner(umi);
+
+  await createCollection(umi, {
+    collection,
+    name: 'Test name',
+    uri: 'https://example.com',
+    plugins: [
+      {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+        initPluginAuthority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+      },
+    ],
+  }).sendAndConfirm(umi);
+
+  await assertCollection(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+
+  await updateCollectionPlugin(umi, {
+    collection: collection.publicKey,
+    authority: appDataUpdateAuthority,
+    plugin: {
+      key: {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+      },
+      type: 'AppData',
+      schema: ExternalPluginAdapterSchema.Binary,
+    },
+  }).sendAndConfirm(umi);
+
+  await assertCollection(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Binary,
+      },
+    ],
+  });
+});
+
+test('it cannot update oracle on collection using update authority when different from external plugin authority', async (t) => {
+  const umi = await createUmi();
+  const collection = generateSigner(umi);
+  const dataAuthority = generateSigner(umi);
+  const appDataUpdateAuthority = generateSigner(umi);
+
+  await createCollection(umi, {
+    collection,
+    name: 'Test name',
+    uri: 'https://example.com',
+    plugins: [
+      {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+        initPluginAuthority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+      },
+    ],
+  }).sendAndConfirm(umi);
+
+  await assertCollection(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+
+  const result = updateCollectionPlugin(umi, {
+    collection: collection.publicKey,
+    authority: umi.identity,
+    plugin: {
+      key: {
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+      },
+      type: 'AppData',
+      schema: ExternalPluginAdapterSchema.Binary,
+    },
+  }).sendAndConfirm(umi);
+
+  await t.throwsAsync(result, { name: 'InvalidAuthority' });
+
+  await assertCollection(t, umi, {
+    uri: 'https://example.com',
+    name: 'Test name',
+    collection: collection.publicKey,
+    updateAuthority: umi.identity.publicKey,
+    appDatas: [
+      {
+        authority: {
+          type: 'Address',
+          address: appDataUpdateAuthority.publicKey,
+        },
+        type: 'AppData',
+        dataAuthority: { type: 'Address', address: dataAuthority.publicKey },
+        schema: ExternalPluginAdapterSchema.Json,
       },
     ],
   });

--- a/clients/js/test/externalPlugins/dataSection.test.ts
+++ b/clients/js/test/externalPlugins/dataSection.test.ts
@@ -84,7 +84,7 @@ test('it cannot add a DataSection to an asset', async (t) => {
     },
   }).sendAndConfirm(umi);
 
-  await t.throwsAsync(result, { name: 'InvalidAuthority' });
+  await t.throwsAsync(result, { name: 'CannotAddDataSection' });
 });
 
 test('it cannot add a DataSection to a collection', async (t) => {
@@ -108,5 +108,5 @@ test('it cannot add a DataSection to a collection', async (t) => {
     },
   }).sendAndConfirm(umi);
 
-  await t.throwsAsync(result, { name: 'InvalidAuthority' });
+  await t.throwsAsync(result, { name: 'CannotAddDataSection' });
 });

--- a/programs/mpl-core/src/plugins/external_plugin_adapters.rs
+++ b/programs/mpl-core/src/plugins/external_plugin_adapters.rs
@@ -122,6 +122,18 @@ impl ExternalPluginAdapter {
             ) => {
                 app_data.update(update_info);
             }
+            (
+                ExternalPluginAdapter::LinkedLifecycleHook(linked_lifecycle_hook),
+                ExternalPluginAdapterUpdateInfo::LinkedLifecycleHook(update_info),
+            ) => {
+                linked_lifecycle_hook.update(update_info);
+            }
+            (
+                ExternalPluginAdapter::LinkedAppData(linked_app_data),
+                ExternalPluginAdapterUpdateInfo::LinkedAppData(update_info),
+            ) => {
+                linked_app_data.update(update_info);
+            }
             _ => unreachable!(),
         }
     }

--- a/programs/mpl-core/src/processor/add_external_plugin_adapter.rs
+++ b/programs/mpl-core/src/processor/add_external_plugin_adapter.rs
@@ -50,6 +50,18 @@ pub(crate) fn add_external_plugin_adapter<'a>(
         return Err(MplCoreError::NotAvailable.into());
     }
 
+    // TODO: This should be handled in the validate call.
+    match args.init_info {
+        ExternalPluginAdapterInitInfo::LinkedLifecycleHook(_)
+        | ExternalPluginAdapterInitInfo::LinkedAppData(_) => {
+            return Err(MplCoreError::InvalidPluginAdapterTarget.into())
+        }
+        ExternalPluginAdapterInitInfo::DataSection(_) => {
+            return Err(MplCoreError::CannotAddDataSection.into())
+        }
+        _ => (),
+    }
+
     let validation_ctx = PluginValidationContext {
         accounts,
         asset_info: Some(ctx.accounts.asset),
@@ -130,6 +142,10 @@ pub(crate) fn add_collection_external_plugin_adapter<'a>(
         if log_wrapper.key != &spl_noop::ID {
             return Err(MplCoreError::InvalidLogWrapperProgram.into());
         }
+    }
+
+    if let ExternalPluginAdapterInitInfo::DataSection(_) = args.init_info {
+        return Err(MplCoreError::CannotAddDataSection.into());
     }
 
     let validation_ctx = PluginValidationContext {


### PR DESCRIPTION
* Add tests for updating `AppData` and `LinkedAppData` with an authority other than asset/collection update authority.
* Add tests for not being able to add `LinkedAppData` to an asset.
* Fix when `InitInfoArgs` and `UpdateInfoArgs` base conversions of schema enum  (`schema: 0` should not be turned into `schema: null`).
* Fix `update_external_plugin_adapter` program code to be able to update `LinkedAppData` and `LinkedLifecycleHook`.
* Fix `add_external_plugin_adapter` program code to prevent adding `LinkedAppData` and `LinkedLifecycleHook`.
* Make adding `DataSection` explicitly fail for both asset and collection, providing the specific `CannotAddDataSection` rather than just `InvalidAuthority`.
