### PR TITLE
new helper fetchAllAssets

### DIFF
--- a/clients/js/src/helpers/fetch.ts
+++ b/clients/js/src/helpers/fetch.ts
@@ -148,6 +148,22 @@ export const fetchAsset = async (
 };
 
 /**
+ * Helper function to fetch multiple assets and derive plugins from their collections if applicable.
+ *
+ * @param umi Context
+ * @param assets Array of asset addresses to fetch
+ * @param options Options, `skipDerivePlugins` plugins from collection is false by default
+ * @returns Promise of a list of `AssetV1`
+ */
+export const fetchAllAssets = async (
+  umi: Context,
+  assets: Array<PublicKey | string>,
+  options: { skipDerivePlugins?: boolean } & RpcGetAccountOptions = {}
+): Promise<AssetV1[]> => {
+  return Promise.all(assets.map((asset) => fetchAsset(umi, asset, options)));
+};
+
+/**
  * Helper function to fetch a collection.
  *
  * @param umi


### PR DESCRIPTION
Similar to fetchAllAssetsV1 accepts an array of publicKeys and fetches all of them, including the collection plugins.
In case multiple assets are part of the same collection the collection is only fetched once.