### PR TITLE
Removing double validation

### DIFF
--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -661,7 +661,6 @@ pub(crate) trait PluginValidation {
 /// The STRONGEST result is returned.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub(crate) fn validate_plugin_checks<'a>(
-    key: Key,
     accounts: &'a [AccountInfo<'a>],
     checks: &BTreeMap<PluginType, (Key, CheckResult, RegistryRecord)>,
     authority: &'a AccountInfo<'a>,
@@ -683,13 +682,11 @@ pub(crate) fn validate_plugin_checks<'a>(
     let mut approved = false;
     let mut rejected = false;
     for (check_key, check_result, registry_record) in checks.values() {
-        if *check_key == key
-            && matches!(
-                check_result,
-                CheckResult::CanApprove | CheckResult::CanReject
-            )
-        {
-            let account = match key {
+        if matches!(
+            check_result,
+            CheckResult::CanApprove | CheckResult::CanReject
+        ) {
+            let account = match check_key {
                 Key::CollectionV1 => collection.ok_or(MplCoreError::InvalidCollection)?,
                 Key::AssetV1 => asset.ok_or(MplCoreError::InvalidAsset)?,
                 _ => unreachable!(),
@@ -738,7 +735,6 @@ pub(crate) fn validate_plugin_checks<'a>(
 /// The STRONGEST result is returned.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub(crate) fn validate_external_plugin_adapter_checks<'a>(
-    key: Key,
     accounts: &'a [AccountInfo<'a>],
     external_checks: &BTreeMap<
         ExternalPluginAdapterKey,
@@ -762,12 +758,8 @@ pub(crate) fn validate_external_plugin_adapter_checks<'a>(
 ) -> Result<ValidationResult, ProgramError> {
     let mut approved = false;
     for (check_key, check_result, external_registry_record) in external_checks.values() {
-        if *check_key == key
-            && (check_result.can_listen()
-                || check_result.can_approve()
-                || check_result.can_reject())
-        {
-            let account = match key {
+        if check_result.can_listen() || check_result.can_approve() || check_result.can_reject() {
+            let account = match check_key {
                 Key::CollectionV1 => collection.ok_or(MplCoreError::InvalidCollection)?,
                 Key::AssetV1 => asset.ok_or(MplCoreError::InvalidAsset)?,
                 _ => unreachable!(),

--- a/programs/mpl-core/src/utils/mod.rs
+++ b/programs/mpl-core/src/utils/mod.rs
@@ -243,32 +243,6 @@ pub(crate) fn validate_asset_permissions<'a>(
     };
 
     match validate_plugin_checks(
-        Key::CollectionV1,
-        accounts,
-        &checks,
-        authority_info,
-        new_owner,
-        new_authority,
-        None,
-        new_plugin,
-        new_plugin_authority,
-        new_external_plugin_adapter,
-        new_external_plugin_adapter_authority,
-        Some(asset),
-        collection,
-        &resolved_authorities,
-        plugin_validate_fp,
-    )? {
-        ValidationResult::Approved => approved = true,
-        ValidationResult::Rejected => rejected = true,
-        ValidationResult::Pass => (),
-        ValidationResult::ForceApproved => {
-            return Ok((deserialized_asset, plugin_header, plugin_registry))
-        }
-    };
-
-    match validate_plugin_checks(
-        Key::AssetV1,
         accounts,
         &checks,
         authority_info,
@@ -294,31 +268,6 @@ pub(crate) fn validate_asset_permissions<'a>(
 
     if let Some(external_plugin_adapter_validate_fp) = external_plugin_adapter_validate_fp {
         match validate_external_plugin_adapter_checks(
-            Key::CollectionV1,
-            accounts,
-            &external_checks,
-            authority_info,
-            new_owner,
-            new_authority,
-            None,
-            new_plugin,
-            new_plugin_authority,
-            new_external_plugin_adapter,
-            new_external_plugin_adapter_authority,
-            Some(asset),
-            collection,
-            &resolved_authorities,
-            external_plugin_adapter_validate_fp,
-        )? {
-            ValidationResult::Approved => approved = true,
-            ValidationResult::Rejected => rejected = true,
-            ValidationResult::Pass => (),
-            // Force approved will not be possible from external plugin adapters.
-            ValidationResult::ForceApproved => unreachable!(),
-        };
-
-        match validate_external_plugin_adapter_checks(
-            Key::AssetV1,
             accounts,
             &external_checks,
             authority_info,
@@ -450,7 +399,6 @@ pub(crate) fn validate_collection_permissions<'a>(
     };
 
     match validate_plugin_checks(
-        Key::CollectionV1,
         accounts,
         &checks,
         authority_info,
@@ -476,7 +424,6 @@ pub(crate) fn validate_collection_permissions<'a>(
 
     if let Some(external_plugin_adapter_validate_fp) = external_plugin_adapter_validate_fp {
         match validate_external_plugin_adapter_checks(
-            Key::CollectionV1,
             accounts,
             &external_checks,
             authority_info,


### PR DESCRIPTION
After reviewing the asset validation code it seems like we're unnecessarily performing separate validations on both Asset and Collection plugins. Deduplication is already handled by the `checks` `BtreeMap` so I don't believe we actually need to do these separately

If that's not the case then we need to update the tests to appropriately prove out why these validations should be separate.