### PR TITLE
Moving ME checks to the plugin.

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  path_instructions:
+    [
+      {
+        path: "programs/mpl-core/src/processor/*",
+        instructions: "Make sure the owner is checked on all accounts somehow",
+      },
+      {
+        path: "programs/mpl-core/*",
+        instructions: "Carefully consider performance implications and make sure there are no performance inefficiencies",
+      },
+      {
+        path: "**/*.rs",
+        instructions: "Make duplicated logic between the rust client and program are consistent",
+      },
+    ]
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/clients/js/src/generated/errors/mplCore.ts
+++ b/clients/js/src/generated/errors/mplCore.ts
@@ -726,6 +726,19 @@ export class InvalidExecutePdaError extends ProgramError {
 codeToErrorMap.set(0x31, InvalidExecutePdaError);
 nameToErrorMap.set('InvalidExecutePda', InvalidExecutePdaError);
 
+/** PluginNotAllowedOnAsset: Plugin is not allowed to be added to an Asset */
+export class PluginNotAllowedOnAssetError extends ProgramError {
+  override readonly name: string = 'PluginNotAllowedOnAsset';
+
+  readonly code: number = 0x32; // 50
+
+  constructor(program: Program, cause?: Error) {
+    super('Plugin is not allowed to be added to an Asset', program, cause);
+  }
+}
+codeToErrorMap.set(0x32, PluginNotAllowedOnAssetError);
+nameToErrorMap.set('PluginNotAllowedOnAsset', PluginNotAllowedOnAssetError);
+
 /**
  * Attempts to resolve a custom program error from the provided error code.
  * @category Errors

--- a/clients/js/test/plugins/collection/masterEdition.test.ts
+++ b/clients/js/test/plugins/collection/masterEdition.test.ts
@@ -128,7 +128,7 @@ test('it cannot add masterEdition to asset', async (t) => {
   }).sendAndConfirm(umi);
 
   await t.throwsAsync(result, {
-    name: 'InvalidPlugin',
+    name: 'PluginNotAllowedOnAsset',
   });
 });
 
@@ -150,6 +150,6 @@ test('it cannot create asset with masterEdition', async (t) => {
   });
 
   await t.throwsAsync(result, {
-    name: 'InvalidPlugin',
+    name: 'PluginNotAllowedOnAsset',
   });
 });

--- a/clients/rust/src/generated/errors/mpl_core.rs
+++ b/clients/rust/src/generated/errors/mpl_core.rs
@@ -160,6 +160,9 @@ pub enum MplCoreError {
     /// 49 (0x31) - Invalid Signing PDA for Asset or Collection Execute
     #[error("Invalid Signing PDA for Asset or Collection Execute")]
     InvalidExecutePda,
+    /// 50 (0x32) - Plugin is not allowed to be added to an Asset
+    #[error("Plugin is not allowed to be added to an Asset")]
+    PluginNotAllowedOnAsset,
 }
 
 impl solana_program::program_error::PrintProgramError for MplCoreError {

--- a/idls/mpl_core.json
+++ b/idls/mpl_core.json
@@ -4949,6 +4949,11 @@
       "code": 49,
       "name": "InvalidExecutePda",
       "msg": "Invalid Signing PDA for Asset or Collection Execute"
+    },
+    {
+      "code": 50,
+      "name": "PluginNotAllowedOnAsset",
+      "msg": "Plugin is not allowed to be added to an Asset"
     }
   ],
   "metadata": {

--- a/programs/mpl-core/src/error.rs
+++ b/programs/mpl-core/src/error.rs
@@ -208,6 +208,10 @@ pub enum MplCoreError {
     /// 49 - Invalid Signing PDA for Asset or Collection Execute
     #[error("Invalid Signing PDA for Asset or Collection Execute")]
     InvalidExecutePda,
+
+    /// 50 - Plugin is not allowed to be added to an Asset
+    #[error("Plugin is not allowed to be added to an Asset")]
+    PluginNotAllowedOnAsset,
 }
 
 impl PrintProgramError for MplCoreError {

--- a/programs/mpl-core/src/plugins/lifecycle.rs
+++ b/programs/mpl-core/src/plugins/lifecycle.rs
@@ -91,6 +91,7 @@ impl PluginType {
             PluginType::Edition => CheckResult::CanReject,
             PluginType::Autograph => CheckResult::CanReject,
             PluginType::VerifiedCreators => CheckResult::CanReject,
+            PluginType::MasterEdition => CheckResult::CanReject,
             _ => CheckResult::None,
         }
     }
@@ -142,6 +143,7 @@ impl PluginType {
             PluginType::UpdateDelegate => CheckResult::CanApprove,
             PluginType::Autograph => CheckResult::CanReject,
             PluginType::VerifiedCreators => CheckResult::CanReject,
+            PluginType::MasterEdition => CheckResult::CanReject,
             _ => CheckResult::None,
         }
     }

--- a/programs/mpl-core/src/processor/add_plugin.rs
+++ b/programs/mpl-core/src/processor/add_plugin.rs
@@ -47,12 +47,6 @@ pub(crate) fn add_plugin<'a>(
         return Err(MplCoreError::NotAvailable.into());
     }
 
-    // TODO move into plugin validation when asset/collection is part of validation context
-    let plugin_type = PluginType::from(&args.plugin);
-    if plugin_type == PluginType::MasterEdition {
-        return Err(MplCoreError::InvalidPlugin.into());
-    }
-
     let target_plugin_authority = args.init_authority.unwrap_or(args.plugin.manager());
 
     // TODO: Seed with Rejected

--- a/programs/mpl-core/src/processor/create.rs
+++ b/programs/mpl-core/src/processor/create.rs
@@ -183,11 +183,6 @@ pub(crate) fn process_create<'a>(
                         ctx.accounts.system_program,
                     )?;
                 for plugin in &plugins {
-                    // TODO move into plugin validation when asset/collection is part of validation context
-                    let plugin_type = PluginType::from(&plugin.plugin);
-                    if plugin_type == PluginType::MasterEdition {
-                        return Err(MplCoreError::InvalidPlugin.into());
-                    }
                     if PluginType::check_create(&PluginType::from(&plugin.plugin))
                         != CheckResult::None
                     {
@@ -201,7 +196,7 @@ pub(crate) fn process_create<'a>(
                             new_owner: None,
                             new_asset_authority: None,
                             new_collection_authority: None,
-                            target_plugin: None,
+                            target_plugin: Some(&plugin.plugin),
                             target_plugin_authority: None,
                             target_external_plugin: None,
                             target_external_plugin_authority: None,


### PR DESCRIPTION
Moving the ME checks preventing creation to the plugin validators instead of the top level processors.

I had to add the plugin as the target plugin in the create validator but that shouldn't effect anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new error condition for plugins not allowed on assets.
  - Added validations for the creation and addition of master edition plugins.
  - Implemented handling for the master edition plugin within lifecycle checks.
  - New configuration file for YAML language server settings and review processes.

- **Bug Fixes**
  - Improved error feedback by providing clearer messages when plugins are not permitted.

- **Tests**
  - Updated test cases to confirm the revised validation logic and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->