### PR TITLE
Add key checks in Rust client

### DIFF
--- a/clients/rust/src/hooked/asset.rs
+++ b/clients/rust/src/hooked/asset.rs
@@ -3,14 +3,21 @@ use anchor_lang::prelude::AnchorSerialize;
 #[cfg(not(feature = "anchor"))]
 use borsh::BorshSerialize;
 
+use std::io::ErrorKind;
+
 use crate::{
     accounts::{BaseAssetV1, PluginHeaderV1},
-    registry_records_to_external_plugin_adapter_list, registry_records_to_plugin_list, Asset,
-    ExternalPluginAdaptersList, PluginRegistryV1Safe, PluginsList,
+    registry_records_to_external_plugin_adapter_list, registry_records_to_plugin_list,
+    types::Key,
+    Asset, ExternalPluginAdaptersList, PluginRegistryV1Safe, PluginsList,
 };
 
 impl Asset {
     pub fn deserialize(data: &[u8]) -> Result<Box<Self>, std::io::Error> {
+        if Key::from_slice(data, 0)? != Key::AssetV1 {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
         let base = BaseAssetV1::from_bytes(data)?;
         let base_data = base.try_to_vec()?;
 

--- a/clients/rust/src/hooked/collection.rs
+++ b/clients/rust/src/hooked/collection.rs
@@ -3,14 +3,21 @@ use anchor_lang::prelude::AnchorSerialize;
 #[cfg(not(feature = "anchor"))]
 use borsh::BorshSerialize;
 
+use std::io::ErrorKind;
+
 use crate::{
     accounts::{BaseCollectionV1, PluginHeaderV1},
-    registry_records_to_external_plugin_adapter_list, registry_records_to_plugin_list, Collection,
-    ExternalPluginAdaptersList, PluginRegistryV1Safe, PluginsList,
+    registry_records_to_external_plugin_adapter_list, registry_records_to_plugin_list,
+    types::Key,
+    Collection, ExternalPluginAdaptersList, PluginRegistryV1Safe, PluginsList,
 };
 
 impl Collection {
     pub fn deserialize(data: &[u8]) -> Result<Box<Self>, std::io::Error> {
+        if Key::from_slice(data, 0)? != Key::CollectionV1 {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
         let base = BaseCollectionV1::from_bytes(data)?;
         let base_data = base.try_to_vec()?;
 

--- a/clients/rust/src/hooked/mod.rs
+++ b/clients/rust/src/hooked/mod.rs
@@ -175,14 +175,29 @@ impl SolanaAccount for PluginHeaderV1 {
     }
 }
 
+impl Key {
+    /// Load the one byte key from a slice of data at the given offset.
+    pub fn from_slice(data: &[u8], offset: usize) -> Result<Self, std::io::Error> {
+        let key_byte = *data.get(offset).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                MplCoreError::DeserializationError.to_string(),
+            )
+        })?;
+
+        Self::from_u8(key_byte).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                MplCoreError::DeserializationError.to_string(),
+            )
+        })
+    }
+}
+
 /// Load the one byte key from the account data at the given offset.
 pub fn load_key(account: &AccountInfo, offset: usize) -> Result<Key, std::io::Error> {
-    let key = Key::from_u8((*account.data).borrow()[offset]).ok_or(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        MplCoreError::DeserializationError.to_string(),
-    ))?;
-
-    Ok(key)
+    let data = account.data.borrow();
+    Key::from_slice(&data, offset)
 }
 
 /// A trait for generic blobs of data that have size.

--- a/clients/rust/src/indexable_asset.rs
+++ b/clients/rust/src/indexable_asset.rs
@@ -498,6 +498,10 @@ impl IndexableAsset {
     /// Fetch the base `Asset`` or `Collection`` and all the plugins and store in an
     /// `IndexableAsset`.
     pub fn fetch(key: Key, account: &[u8]) -> Result<Self, std::io::Error> {
+        if Key::from_slice(account, 0)? != key {
+            return Err(ErrorKind::InvalidInput.into());
+        }
+
         let (mut indexable_asset, base_size) = match key {
             Key::AssetV1 => {
                 let asset = BaseAssetV1::from_bytes(account)?;


### PR DESCRIPTION
Add key checks to help disambiguate issues with deserialization of assets and collections.