### PR TITLE
fix: resolve Anchor dependency conflicts in Rust client (#196)

### DIFF
--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -26,12 +26,12 @@ rmp-serde = "1.0"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_json = "1.0"
 serde_with = { version = "^3.0", optional = true }
-solana-program = "> 1.14"
+solana-program = "^1.17"
 thiserror = "^1.0"
 
 kaigan = { version = "0.2.6", features = ["serde"], optional = false }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-solana-program-test = "> 1.14"
-solana-sdk = "> 1.14"
+solana-program-test = "^1.17"
+solana-sdk = "^1.17"


### PR DESCRIPTION
## Summary

Resolves dependency version conflicts between MPL Core Rust client and Anchor framework that prevented compilation of Anchor projects using MPL Core.

## Problem

Issue #196: Users encountered `expected 'anchor_lang::prelude::Pubkey', found '__Pubkey'` errors when building Anchor projects with MPL Core due to incompatible `solana-program` version constraints.

## Solution

Updated `clients/rust/Cargo.toml` dependency constraints:

```diff
- solana-program = "> 1.14"
+ solana-program = "^1.17"
- solana-program-test = "> 1.14"  
+ solana-program-test = "^1.17"
- solana-sdk = "> 1.14"
+ solana-sdk = "^1.17"
```

This aligns the client dependencies with the program's `solana-program = "^1.17"` constraint, ensuring consistent dependency resolution.

## Testing

- Verified successful compilation of Anchor + MPL Core projects
- Confirmed no regression in existing functionality
- Validated compatibility with Anchor 0.30.x

## Impact

Enables developers to use MPL Core in Anchor-based applications without dependency conflicts.

Closes #196