### PR TITLE
fix(js-kit): ignore generated files in lint

### DIFF
--- a/clients/js-kit/.eslintrc.js
+++ b/clients/js-kit/.eslintrc.js
@@ -19,5 +19,5 @@ module.exports = {
     'no-param-reassign': 'off',
     'func-names': 'off',
   },
-  ignorePatterns: ['dist/**', '.eslintrc.js'],
+  ignorePatterns: ['dist/**', '.eslintrc.js', 'src/generated/**'],
 };

--- a/clients/js-kit/src/hash.ts
+++ b/clients/js-kit/src/hash.ts
@@ -2,13 +2,16 @@ import { keccak_256 } from '@noble/hashes/sha3';
 
 function mergeBytes(arrays: Uint8Array[]): Uint8Array {
   const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
-  for (const arr of arrays) {
-    result.set(arr, offset);
-    offset += arr.length;
-  }
-  return result;
+  return arrays.reduce(
+    (state, arr) => {
+      state.result.set(arr, state.offset);
+      return {
+        offset: state.offset + arr.length,
+        result: state.result,
+      };
+    },
+    { offset: 0, result: new Uint8Array(totalLength) }
+  ).result;
 }
 
 export function hash(input: Uint8Array | Uint8Array[]): Uint8Array {

--- a/clients/js-kit/src/helpers/gpa.ts
+++ b/clients/js-kit/src/helpers/gpa.ts
@@ -38,78 +38,73 @@ const COLLECTION_UPDATE_AUTHORITY_OFFSET = 1;
 // Base58 alphabet
 const BASE58_ALPHABET =
   '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE10_256 = 256n;
+const BASE58 = 58n;
+
+function countLeadingCharacter(str: string, character: string): number {
+  const firstDifferentCharacter = str
+    .split('')
+    .findIndex((char) => char !== character);
+  return firstDifferentCharacter === -1 ? str.length : firstDifferentCharacter;
+}
+
+function countLeadingZeroBytes(bytes: Uint8Array): number {
+  const firstNonZeroByte = bytes.findIndex((byte) => byte !== 0);
+  return firstNonZeroByte === -1 ? bytes.length : firstNonZeroByte;
+}
+
+function encodeBase58Value(value: bigint): string {
+  if (value === 0n) {
+    return '';
+  }
+
+  const quotient = value / BASE58;
+  const remainder = Number(value % BASE58);
+  return `${encodeBase58Value(quotient)}${BASE58_ALPHABET[remainder]}`;
+}
+
+function decodeBase58Value(str: string): bigint {
+  return str.split('').reduce((value, char) => {
+    const nextDigit = BASE58_ALPHABET.indexOf(char);
+    if (nextDigit === -1) {
+      throw new Error(`Invalid base58 character: ${char}`);
+    }
+    return value * BASE58 + BigInt(nextDigit);
+  }, 0n);
+}
+
+function bigintToBytes(value: bigint): number[] {
+  if (value === 0n) {
+    return [];
+  }
+
+  const quotient = value / BASE10_256;
+  const remainder = Number(value % BASE10_256);
+  return [...bigintToBytes(quotient), remainder];
+}
 
 // Simple base58 encoder
 function encodeBase58(bytes: Uint8Array): Base58EncodedBytes {
   if (bytes.length === 0) return '' as Base58EncodedBytes;
 
-  // Count leading zeros
-  let zeros = 0;
-  while (zeros < bytes.length && bytes[zeros] === 0) {
-    zeros++;
-  }
-
-  // Convert to base58
-  const input = Array.from(bytes);
-  const encoded: number[] = [];
-
-  for (const byte of input) {
-    let carry = byte;
-    for (let j = 0; j < encoded.length; j++) {
-      carry += encoded[j] << 8;
-      encoded[j] = carry % 58;
-      carry = Math.floor(carry / 58);
-    }
-    while (carry > 0) {
-      encoded.push(carry % 58);
-      carry = Math.floor(carry / 58);
-    }
-  }
-
-  // Add leading '1's for zero bytes
-  let result = '1'.repeat(zeros);
-  for (let i = encoded.length - 1; i >= 0; i--) {
-    result += BASE58_ALPHABET[encoded[i]];
-  }
-
-  return result as Base58EncodedBytes;
+  const leadingZeroCount = countLeadingZeroBytes(bytes);
+  const encodedValue = bytes.reduce(
+    (value, byte) => value * BASE10_256 + BigInt(byte),
+    0n
+  );
+  return `${'1'.repeat(leadingZeroCount)}${encodeBase58Value(encodedValue)}` as Base58EncodedBytes;
 }
 
 // Simple base58 decoder
 function decodeBase58(str: string): Uint8Array {
   if (str.length === 0) return new Uint8Array(0);
 
-  // Count leading '1's
-  let zeros = 0;
-  while (zeros < str.length && str[zeros] === '1') {
-    zeros++;
-  }
-
-  // Decode from base58
-  const decoded: number[] = [];
-  for (const char of str) {
-    const value = BASE58_ALPHABET.indexOf(char);
-    if (value === -1) throw new Error(`Invalid base58 character: ${char}`);
-
-    let carry = value;
-    for (let j = 0; j < decoded.length; j++) {
-      carry += decoded[j] * 58;
-      decoded[j] = carry & 0xff;
-      carry >>= 8;
-    }
-    while (carry > 0) {
-      decoded.push(carry & 0xff);
-      carry >>= 8;
-    }
-  }
-
-  // Add leading zeros
-  const result = new Uint8Array(zeros + decoded.length);
-  for (let i = zeros + decoded.length - 1, j = 0; j < decoded.length; i--, j++) {
-    result[i] = decoded[j];
-  }
-
-  return result;
+  const leadingZeroCount = countLeadingCharacter(str, '1');
+  const decodedValue = decodeBase58Value(str.slice(leadingZeroCount));
+  return Uint8Array.from([
+    ...Array.from({ length: leadingZeroCount }, () => 0),
+    ...bigintToBytes(decodedValue),
+  ]);
 }
 
 /**
@@ -144,16 +139,26 @@ export async function fetchAssetsByOwner(
     .send();
 
   const decoder = getAssetV1Decoder();
-  return response.map((item: { pubkey: Address; account: { data: [string, string]; executable: boolean; lamports: bigint; owner: Address } }) => {
-    const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
-    return {
-      address: item.pubkey,
-      data: decoder.decode(data),
-      executable: item.account.executable,
-      lamports: item.account.lamports,
-      programAddress: item.account.owner,
-    } as Account<AssetV1>;
-  });
+  return response.map(
+    (item: {
+      pubkey: Address;
+      account: {
+        data: [string, string];
+        executable: boolean;
+        lamports: bigint;
+        owner: Address;
+      };
+    }) => {
+      const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
+      return {
+        address: item.pubkey,
+        data: decoder.decode(data),
+        executable: item.account.executable,
+        lamports: item.account.lamports,
+        programAddress: item.account.owner,
+      } as Account<AssetV1>;
+    }
+  );
 }
 
 /**
@@ -195,16 +200,26 @@ export async function fetchAssetsByCollection(
     .send();
 
   const decoder = getAssetV1Decoder();
-  return response.map((item: { pubkey: Address; account: { data: [string, string]; executable: boolean; lamports: bigint; owner: Address } }) => {
-    const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
-    return {
-      address: item.pubkey,
-      data: decoder.decode(data),
-      executable: item.account.executable,
-      lamports: item.account.lamports,
-      programAddress: item.account.owner,
-    } as Account<AssetV1>;
-  });
+  return response.map(
+    (item: {
+      pubkey: Address;
+      account: {
+        data: [string, string];
+        executable: boolean;
+        lamports: bigint;
+        owner: Address;
+      };
+    }) => {
+      const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
+      return {
+        address: item.pubkey,
+        data: decoder.decode(data),
+        executable: item.account.executable,
+        lamports: item.account.lamports,
+        programAddress: item.account.owner,
+      } as Account<AssetV1>;
+    }
+  );
 }
 
 /**
@@ -246,16 +261,26 @@ export async function fetchAssetsByUpdateAuthority(
     .send();
 
   const decoder = getAssetV1Decoder();
-  return response.map((item: { pubkey: Address; account: { data: [string, string]; executable: boolean; lamports: bigint; owner: Address } }) => {
-    const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
-    return {
-      address: item.pubkey,
-      data: decoder.decode(data),
-      executable: item.account.executable,
-      lamports: item.account.lamports,
-      programAddress: item.account.owner,
-    } as Account<AssetV1>;
-  });
+  return response.map(
+    (item: {
+      pubkey: Address;
+      account: {
+        data: [string, string];
+        executable: boolean;
+        lamports: bigint;
+        owner: Address;
+      };
+    }) => {
+      const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
+      return {
+        address: item.pubkey,
+        data: decoder.decode(data),
+        executable: item.account.executable,
+        lamports: item.account.lamports,
+        programAddress: item.account.owner,
+      } as Account<AssetV1>;
+    }
+  );
 }
 
 /**
@@ -290,14 +315,24 @@ export async function fetchCollectionsByUpdateAuthority(
     .send();
 
   const decoder = getCollectionV1Decoder();
-  return response.map((item: { pubkey: Address; account: { data: [string, string]; executable: boolean; lamports: bigint; owner: Address } }) => {
-    const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
-    return {
-      address: item.pubkey,
-      data: decoder.decode(data),
-      executable: item.account.executable,
-      lamports: item.account.lamports,
-      programAddress: item.account.owner,
-    } as Account<CollectionV1>;
-  });
+  return response.map(
+    (item: {
+      pubkey: Address;
+      account: {
+        data: [string, string];
+        executable: boolean;
+        lamports: bigint;
+        owner: Address;
+      };
+    }) => {
+      const data = new Uint8Array(Buffer.from(item.account.data[0], 'base64'));
+      return {
+        address: item.pubkey,
+        data: decoder.decode(data),
+        executable: item.account.executable,
+        lamports: item.account.lamports,
+        programAddress: item.account.owner,
+      } as Account<CollectionV1>;
+    }
+  );
 }

--- a/clients/js-kit/src/helpers/state.ts
+++ b/clients/js-kit/src/helpers/state.ts
@@ -1,9 +1,6 @@
 import { type Address, address } from '@solana/addresses';
 import { type AssetV1, type CollectionV1 } from '../generated';
-import {
-  type AssetPluginsList,
-  type CollectionPluginsList,
-} from '../plugins';
+import { type AssetPluginsList, type CollectionPluginsList } from '../plugins';
 
 /**
  * Find the collection address for the given asset if it is part of a collection.
@@ -64,36 +61,44 @@ export function deriveAssetPlugins<T extends AssetV1 & AssetPluginsList>(
   }
 
   // Merge plugins from collection into asset, asset takes precedence
-  const mergedPlugins: Partial<AssetPluginsList> = {};
-
   // List of common plugin keys that can be inherited from collection
   const inheritablePluginKeys: (keyof AssetPluginsList)[] = [
+    'addBlocker',
     'attributes',
+    'autograph',
+    'freezeExecute',
+    'immutableMetadata',
+    'permanentBurnDelegate',
+    'permanentFreezeDelegate',
+    'permanentFreezeExecute',
+    'permanentTransferDelegate',
     'royalties',
     'updateDelegate',
-    'permanentFreezeDelegate',
-    'permanentTransferDelegate',
-    'permanentBurnDelegate',
-    'addBlocker',
-    'immutableMetadata',
-    'autograph',
     'verifiedCreators',
-    'freezeExecute',
-    'permanentFreezeExecute',
   ];
 
-  for (const key of inheritablePluginKeys) {
+  const mergedPlugins = inheritablePluginKeys.reduce((plugins, key) => {
     const assetPlugin = (asset as AssetPluginsList)[key];
     const collectionPlugin = (collection as CollectionPluginsList)[
       key as keyof CollectionPluginsList
     ];
 
     if (assetPlugin) {
-      (mergedPlugins as Record<string, unknown>)[key] = assetPlugin;
-    } else if (collectionPlugin) {
-      (mergedPlugins as Record<string, unknown>)[key] = collectionPlugin;
+      return {
+        ...plugins,
+        [key]: assetPlugin,
+      };
     }
-  }
+
+    if (collectionPlugin) {
+      return {
+        ...plugins,
+        [key]: collectionPlugin,
+      };
+    }
+
+    return plugins;
+  }, {} as Partial<AssetPluginsList>);
 
   return {
     ...asset,

--- a/clients/js-kit/src/plugins/lib.ts
+++ b/clients/js-kit/src/plugins/lib.ts
@@ -12,7 +12,7 @@ import {
   type RegistryRecord,
 } from '../generated';
 
-import { toWords } from '../utils';
+import { someOrNone, toWords } from '../utils';
 import { masterEditionFromBase, masterEditionToBase } from './masterEdition';
 import {
   type PluginAuthority,
@@ -27,7 +27,6 @@ import {
   type PluginAuthorityPairHelperArgs,
   type PluginsList,
 } from './types';
-import { someOrNone } from '../utils';
 
 export function formPluginHeaderV1(
   pluginRegistryOffset: bigint
@@ -139,7 +138,9 @@ export function pluginAuthorityPairV2({
       type,
       ...args,
     } as AssetAllPluginArgsV2),
-    authority: authority ? someOrNone(pluginAuthorityToBase(authority)) : { __option: 'None' },
+    authority: authority
+      ? someOrNone(pluginAuthorityToBase(authority))
+      : { __option: 'None' },
   };
 }
 
@@ -185,7 +186,9 @@ export function mapPlugin({
     [pluginKey]: {
       authority,
       offset,
-      ...('fields' in plug ? mapPluginFields(plug.fields as unknown as Record<string, unknown>[]) : {}),
+      ...('fields' in plug
+        ? mapPluginFields(plug.fields as unknown as Record<string, unknown>[])
+        : {}),
     },
   };
 }
@@ -230,7 +233,10 @@ export function parseExternalPluginAdapterData(
   account: Uint8Array
 ): unknown {
   let data;
-  if (record.dataOffset.__option === 'Some' && record.dataLen.__option === 'Some') {
+  if (
+    record.dataOffset.__option === 'Some' &&
+    record.dataLen.__option === 'Some'
+  ) {
     const dataSlice = account.slice(
       Number(record.dataOffset.value),
       Number(record.dataOffset.value) + Number(record.dataLen.value)
@@ -245,7 +251,10 @@ export function parseExternalPluginAdapterData(
           data = JSON.parse(new TextDecoder().decode(dataSlice));
         } catch (e) {
           // eslint-disable-next-line no-console
-          console.warn('Invalid JSON in external plugin data', (e as Error).message);
+          console.warn(
+            'Invalid JSON in external plugin data',
+            (e as Error).message
+          );
         }
       }
     } else if (plugin.schema === ExternalPluginAdapterSchema.MsgPack) {


### PR DESCRIPTION
Ignore generated JS Kit sources in the local ESLint config.

Refactor the handwritten hash, GPA, state, and plugin helpers to satisfy the existing lint rules while keeping the JS Kit build green.