### PR TITLE
Fix BubblegumV2 to only restrict plugins on collections

### DIFF
--- a/clients/js/test/plugins/collection/bubblegumV2.test.ts
+++ b/clients/js/test/plugins/collection/bubblegumV2.test.ts
@@ -6,14 +6,17 @@ import {
   removeCollectionPluginV1,
   PluginType,
   addCollectionPlugin,
+  addPlugin,
   ExternalPluginAdapterSchema,
 } from '../../../src';
 import {
+  DEFAULT_ASSET,
   DEFAULT_COLLECTION,
+  assertAsset,
   assertCollection,
   createUmi,
 } from '../../_setupRaw';
-import { createCollection } from '../../_setupSdk';
+import { createAsset, createCollection } from '../../_setupSdk';
 
 const MPL_BUBBLEGUM_PROGRAM_ID =
   'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY' as PublicKey<'BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY'>;
@@ -386,5 +389,161 @@ test('it cannot create collection with BubblegumV2 plugin using wrong authority'
 
   await t.throwsAsync(addressResult, {
     name: 'InvalidAuthority',
+  });
+});
+
+test('it can add non-allow-listed plugin to asset in BubblegumV2 collection', async (t) => {
+  const umi = await createUmi();
+  const collection = await createCollection(umi, {
+    plugins: [
+      {
+        type: 'BubblegumV2',
+      },
+    ],
+  });
+
+  const asset = await createAsset(umi, {
+    collection,
+  });
+
+  await addPlugin(umi, {
+    asset: asset.publicKey,
+    collection: collection.publicKey,
+    plugin: {
+      type: 'FreezeDelegate',
+      frozen: false,
+    },
+  }).sendAndConfirm(umi);
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Collection', address: collection.publicKey },
+    freezeDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+      frozen: false,
+    },
+  });
+});
+
+test('it can add external plugin adapter to asset in BubblegumV2 collection', async (t) => {
+  const umi = await createUmi();
+  const collection = await createCollection(umi, {
+    plugins: [
+      {
+        type: 'BubblegumV2',
+      },
+    ],
+  });
+
+  const asset = await createAsset(umi, {
+    collection,
+  });
+
+  await addPlugin(umi, {
+    asset: asset.publicKey,
+    collection: collection.publicKey,
+    plugin: {
+      type: 'AppData',
+      dataAuthority: { type: 'UpdateAuthority' },
+      schema: ExternalPluginAdapterSchema.Json,
+    },
+  }).sendAndConfirm(umi);
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Collection', address: collection.publicKey },
+    appDatas: [
+      {
+        type: 'AppData',
+        authority: { type: 'UpdateAuthority' },
+        dataAuthority: { type: 'UpdateAuthority' },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+});
+
+test('it can create asset with non-allow-listed plugins in BubblegumV2 collection', async (t) => {
+  const umi = await createUmi();
+  const collection = await createCollection(umi, {
+    plugins: [
+      {
+        type: 'BubblegumV2',
+      },
+    ],
+  });
+
+  const asset = await createAsset(umi, {
+    collection,
+    plugins: [
+      {
+        type: 'FreezeDelegate',
+        frozen: false,
+      },
+      {
+        type: 'TransferDelegate',
+      },
+    ],
+  });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Collection', address: collection.publicKey },
+    freezeDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+      frozen: false,
+    },
+    transferDelegate: {
+      authority: {
+        type: 'Owner',
+      },
+    },
+  });
+});
+
+test('it can create asset with external plugin adapter in BubblegumV2 collection', async (t) => {
+  const umi = await createUmi();
+  const collection = await createCollection(umi, {
+    plugins: [
+      {
+        type: 'BubblegumV2',
+      },
+    ],
+  });
+
+  const asset = await createAsset(umi, {
+    collection,
+    plugins: [
+      {
+        type: 'AppData',
+        dataAuthority: { type: 'UpdateAuthority' },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
+  });
+
+  await assertAsset(t, umi, {
+    ...DEFAULT_ASSET,
+    asset: asset.publicKey,
+    owner: umi.identity.publicKey,
+    updateAuthority: { type: 'Collection', address: collection.publicKey },
+    appDatas: [
+      {
+        type: 'AppData',
+        authority: { type: 'UpdateAuthority' },
+        dataAuthority: { type: 'UpdateAuthority' },
+        schema: ExternalPluginAdapterSchema.Json,
+      },
+    ],
   });
 });

--- a/programs/mpl-core/src/plugins/internal/permanent/bubblegum_v2.rs
+++ b/programs/mpl-core/src/plugins/internal/permanent/bubblegum_v2.rs
@@ -43,21 +43,19 @@ impl PluginValidation for BubblegumV2 {
         &self,
         ctx: &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError> {
-        // Only restrict plugins on the collection itself. Assets in the
-        // collection flow through the Core program and are not affected by
-        // BubblegumV2 plugin restrictions.
-        if ctx.asset_info.is_some() {
-            return abstain!();
-        }
-
         if let Some(target_plugin) = ctx.target_plugin {
             let plugin_type = PluginType::from(target_plugin);
-            if Self::ALLOW_LIST.contains(&plugin_type) {
-                abstain!()
-            } else if plugin_type == PluginType::BubblegumV2 {
+            if plugin_type == PluginType::BubblegumV2 {
                 // This plugin can only be added at creation time, so we
-                // always reject it.
+                // always reject it regardless of asset or collection.
                 reject!()
+            } else if ctx.asset_info.is_some() {
+                // Only restrict other plugins on the collection itself.
+                // Assets in the collection flow through the Core program
+                // and are not affected by BubblegumV2 plugin restrictions.
+                abstain!()
+            } else if Self::ALLOW_LIST.contains(&plugin_type) {
+                abstain!()
             } else {
                 // All other plugins are not allowed on Bubblegum
                 // collections.

--- a/programs/mpl-core/src/plugins/internal/permanent/bubblegum_v2.rs
+++ b/programs/mpl-core/src/plugins/internal/permanent/bubblegum_v2.rs
@@ -43,6 +43,13 @@ impl PluginValidation for BubblegumV2 {
         &self,
         ctx: &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError> {
+        // Only restrict plugins on the collection itself. Assets in the
+        // collection flow through the Core program and are not affected by
+        // BubblegumV2 plugin restrictions.
+        if ctx.asset_info.is_some() {
+            return abstain!();
+        }
+
         if let Some(target_plugin) = ctx.target_plugin {
             let plugin_type = PluginType::from(target_plugin);
             if Self::ALLOW_LIST.contains(&plugin_type) {
@@ -76,8 +83,15 @@ impl PluginValidation for BubblegumV2 {
 
     fn validate_add_external_plugin_adapter(
         &self,
-        _ctx: &PluginValidationContext,
+        ctx: &PluginValidationContext,
     ) -> Result<ValidationResult, ProgramError> {
+        // Only restrict external plugin adapters on the collection itself.
+        // Assets in the collection are not affected by BubblegumV2
+        // restrictions since they flow through the Core program.
+        if ctx.asset_info.is_some() {
+            return abstain!();
+        }
+
         // If the BubblegumV2 plugin is present, no external plugin adapters
         // can be added.  The BubblegumV2 plugin limits what can be on the
         // collection to plugins that are supported and validated at runtime


### PR DESCRIPTION
BubblegumV2's allowlist was incorrectly blocking non-allowlisted plugins and external plugin adapters from being added to assets in the collection. Since regular Core assets flow through the Core program (not Bubblegum), only the collection itself should be restricted. The allowlist exists to prevent confusion about which plugins affect bubblegum cNFTs, but should not limit what can be on other assets.