### PR TITLE
Fix deploy env tag updates

### DIFF
--- a/.github/workflows/deploy-program.yml
+++ b/.github/workflows/deploy-program.yml
@@ -279,7 +279,7 @@ jobs:
         uses: actions/github-script@v7
         if: github.event.inputs.dry_run == 'false'
         with:
-          github-token: ${{ secrets.GH_TAGGER_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const refData = await github.rest.git.getRef({
               owner: context.repo.owner,
@@ -294,12 +294,13 @@ jobs:
               repo: context.repo.repo,
               ref: 'refs/tags/${{ needs.check_tag.outputs.program }}-${{ inputs.cluster }}',
               sha: refData.data.object.sha
-            }).catch(err => {
+            }).catch(async (err) => {
               if (err.status !== 422) throw err;
-              github.rest.git.updateRef({
+              await github.rest.git.updateRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'tags/${{ needs.check_tag.outputs.program }}-${{ inputs.cluster }}',
-                sha: refData.data.object.sha
+                sha: refData.data.object.sha,
+                force: true
               });
             })


### PR DESCRIPTION
## Summary
- Replaces the expired custom tagger token with the workflow `GITHUB_TOKEN` for deploy env tag writes.
- Awaits the existing-tag fallback and force-updates the env tag so cluster markers can move to the deployed release SHA.

## Test plan
- `git diff --check`
- `actionlint .github/workflows/deploy-program.yml` skipped because `actionlint` is not installed locally.

## Context
Mirrors the deploy workflow fix from https://github.com/metaplex-foundation/mpl-distro/pull/28 after `release/core@0.13.1` deploys failed in the final env tag step with `401 Bad credentials`.