### PR TITLE
Anchor 0.32.1 compatability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,8 +3553,10 @@ name = "mpl-core"
 version = "0.11.1"
 dependencies = [
  "anchor-lang 0.31.1",
+ "anchor-lang 0.32.1",
  "assert_matches",
  "base64 0.22.1",
+ "borsh 0.10.4",
  "borsh 1.6.1",
  "kaigan",
  "modular-bitfield",
@@ -3564,6 +3566,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "solana-program 2.3.0",
  "solana-program 3.0.0",
  "solana-program-error 3.0.0",
  "solana-program-test",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -20,7 +20,7 @@ anchor = [
     "dep:solana-program-2",
     "kaigan/anchor",
 ]
-anchor-0-32 = ["dep:anchor-lang-0-32"]
+anchor-0-32 = ["anchor", "dep:anchor-lang-0-32"]
 serde = ["dep:serde", "dep:serde_with"]
 test-sbf = []
 borsh-v1 = ["kaigan/borsh-v1"]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -12,15 +12,25 @@ crate-type = ["cdylib", "lib"]
 
 [features]
 default = ["borsh-v1"]
-anchor = ["dep:anchor-lang", "kaigan/anchor"]
+# Anchor is mutually exclusive with the default `borsh-v1` feature.
+# Consumers should set `default-features = false` when enabling `anchor`.
+anchor = [
+    "dep:anchor-lang-0-31",
+    "dep:borsh",
+    "dep:solana-program",
+    "kaigan/anchor",
+]
+anchor-0-32 = ["dep:anchor-lang-0-32"]
 serde = ["dep:serde", "dep:serde_with"]
 test-sbf = []
 borsh-v1 = ["kaigan/borsh-v1"]
 
 [dependencies]
-anchor-lang = { version = "0.31.1", optional = true }
+anchor-lang-0-31 = { package = "anchor-lang", version = "0.31.1", optional = true }
+anchor-lang-0-32 = { package = "anchor-lang", version = "0.32.1", optional = true }
 base64 = "0.22.0"
-borsh = { version = "1.5", features = ["derive"] }
+borsh = { version = "0.10.4", optional = true }
+borsh1 = { package = "borsh", version = "1.5", features = ["derive"] }
 modular-bitfield = "0.11.2"
 num-derive = "^0.4"
 num-traits = "^0.2"
@@ -28,8 +38,9 @@ rmp-serde = "1.0"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_json = "1.0"
 serde_with = { version = "^3.0", optional = true }
-solana-program = "3.0.0"
+solana-program = { version = "2.3.0", optional = true }
 solana-program-error = "3.0.0"
+solana-program-v3 = { package = "solana-program", version = "3.0.0" }
 thiserror = "^1.0"
 
 kaigan = { version = "0.5.0", features = ["serde"], optional = false }

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -17,7 +17,7 @@ default = ["borsh-v1"]
 anchor = [
     "dep:anchor-lang-0-31",
     "dep:borsh",
-    "dep:solana-program",
+    "dep:solana-program-2",
     "kaigan/anchor",
 ]
 anchor-0-32 = ["dep:anchor-lang-0-32"]
@@ -38,9 +38,9 @@ rmp-serde = "1.0"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_json = "1.0"
 serde_with = { version = "^3.0", optional = true }
-solana-program = { version = "2.3.0", optional = true }
+solana-program = "3.0.0"
+solana-program-2 = { package = "solana-program", version = "2.3.0", optional = true }
 solana-program-error = "3.0.0"
-solana-program-v3 = { package = "solana-program", version = "3.0.0" }
 thiserror = "^1.0"
 
 kaigan = { version = "0.5.0", features = ["serde"], optional = false }

--- a/clients/rust/src/hooked/mod.rs
+++ b/clients/rust/src/hooked/mod.rs
@@ -238,7 +238,13 @@ pub trait SolanaAccount: CrateSerialize + CrateDeserialize {
     /// Save the account to the given account info starting at the offset.
     fn save(&self, account: &AccountInfo, offset: usize) -> Result<(), std::io::Error> {
         let mut data = account.data.borrow_mut();
-        self.serialize(&mut &mut data[offset..])
+        let data = data.get_mut(offset..).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                MplCoreError::SerializationError.to_string(),
+            )
+        })?;
+        self.serialize(&mut &mut data[..])
     }
 }
 

--- a/clients/rust/src/hooked/mod.rs
+++ b/clients/rust/src/hooked/mod.rs
@@ -237,7 +237,8 @@ pub trait SolanaAccount: CrateSerialize + CrateDeserialize {
 
     /// Save the account to the given account info starting at the offset.
     fn save(&self, account: &AccountInfo, offset: usize) -> Result<(), std::io::Error> {
-        borsh::to_writer(&mut account.data.borrow_mut()[offset..], self)
+        let mut data = account.data.borrow_mut();
+        self.serialize(&mut &mut data[offset..])
     }
 }
 

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -4,8 +4,8 @@ extern crate anchor_lang_0_31 as anchor_lang;
 extern crate anchor_lang_0_32 as anchor_lang;
 #[cfg(not(feature = "anchor"))]
 extern crate borsh1 as borsh;
-#[cfg(not(feature = "anchor"))]
-extern crate solana_program_v3 as solana_program;
+#[cfg(feature = "anchor")]
+extern crate solana_program_2 as solana_program;
 
 mod generated;
 mod hooked;

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,3 +1,12 @@
+#[cfg(all(feature = "anchor", not(feature = "anchor-0-32")))]
+extern crate anchor_lang_0_31 as anchor_lang;
+#[cfg(all(feature = "anchor", feature = "anchor-0-32"))]
+extern crate anchor_lang_0_32 as anchor_lang;
+#[cfg(not(feature = "anchor"))]
+extern crate borsh1 as borsh;
+#[cfg(not(feature = "anchor"))]
+extern crate solana_program_v3 as solana_program;
+
 mod generated;
 mod hooked;
 mod indexable_asset;


### PR DESCRIPTION
## Summary
- Add an `anchor-0-32` feature to support `anchor-lang 0.32.1` while preserving the existing `anchor` feature on `anchor-lang 0.31.1` to not introduce a breaking change.
- Alias Anchor, Borsh, and Solana dependencies so default builds remain on Borsh v1 / Solana v3 while Anchor builds use the compatible legacy serialization path.
- Replace a Borsh v1-specific writer helper with trait-based serialization so both Anchor and default builds compile.
